### PR TITLE
move from go-ethstorage (resolve warning/ change maxMessageSize)

### DIFF
--- a/ethstorage/p2p/protocol/syncserver.go
+++ b/ethstorage/p2p/protocol/syncserver.go
@@ -155,7 +155,7 @@ func (srv *SyncServer) handleGetBlobsByRangeRequest(ctx context.Context, stream 
 		sucRead++
 		res.Blobs = append(res.Blobs, payload)
 		readBytes += uint64(len(payload.EncodedBlob))
-		if readBytes > req.Bytes || readBytes > maxMessageSize {
+		if readBytes >= req.Bytes || readBytes >= maxMessageSize {
 			break
 		}
 	}
@@ -207,7 +207,7 @@ func (srv *SyncServer) handleGetBlobsByListRequest(ctx context.Context, stream n
 		sucRead++
 		res.Blobs = append(res.Blobs, payload)
 		readBytes += uint64(len(payload.EncodedBlob))
-		if readBytes > req.Bytes || readBytes > maxMessageSize {
+		if readBytes >= req.Bytes || readBytes >= maxMessageSize {
 			break
 		}
 	}


### PR DESCRIPTION
move from go-ethstorage (https://github.com/ethstorage/go-ethstorage/pull/97)

changes: 
1. resolve warnings given by Goland
2. refactor sync_test funcs
3. merge param maxMessageSize, maxRequestSize
4. change `>` to `>=`, so the 4M limit will contain 32 blobs instead of 33 blobs which is strange
    `if readBytes >= req.Bytes || readBytes >= maxMessageSize {`

how to test: 
run the unit tests in sync_test.go