### PR TITLE
sync -- fix ethstorage issues 72 & 95

### DIFF
--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -57,6 +57,7 @@ const (
 const (
 	RequestBlobsByRangeProtocolID = "/ethstorage/dev/requestblobsbyrange/%d/1.0.0"
 	RequestBlobsByListProtocolID  = "/ethstorage/dev/requestblobsbylist/%d/1.0.0"
+	RequestShardList              = "/ethstorage/dev/shardlist/1.0.0"
 )
 
 var (
@@ -787,7 +788,7 @@ func (s *SyncClient) assignFillEmptyBlobTasks() {
 				if err != nil {
 					log.Warn("fill in empty fail", "err", err.Error())
 				} else {
-					log.Warn("fill in empty done", "time", time.Now().Sub(t).Seconds())
+					log.Debug("fill in empty done", "time", time.Now().Sub(t).Seconds())
 				}
 				filled := next - start
 				s.emptyBlobsFilled += filled

--- a/ethstorage/p2p/protocol/syncserver.go
+++ b/ethstorage/p2p/protocol/syncserver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethstorage/go-ethstorage/ethstorage"
 	"github.com/ethstorage/go-ethstorage/ethstorage/rollup"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -280,4 +281,19 @@ func (srv *SyncServer) BlobByIndex(idx uint64) (*BlobPayload, error) {
 		EncodeType:   encodeType,
 		EncodedBlob:  blob,
 	}, nil
+}
+
+func (srv *SyncServer) HandleRequestShardList(ctx context.Context, log log.Logger, stream network.Stream) {
+	rCode := byte(0)
+	bs, err := rlp.EncodeToBytes(ConvertToContractShards(ethstorage.Shards()))
+	if err != nil {
+		log.Warn("encode shard list fail", "err", err.Error())
+		rCode = returnCodeServerError
+	}
+
+	err = WriteMsg(stream, &Msg{rCode, bs})
+	if err != nil {
+		log.Warn("write response failed for HandleRequestShardList", "err", err.Error())
+	}
+	log.Debug("write response done for HandleRequestShardList")
 }


### PR DESCRIPTION
move from https://github.com/ethstorage/go-ethstorage/pull/91.

**Issues to fix:**
1. Issue 72: Request ShardList for connection from the server side as it may not get the ENR (see https://github.com/ethstorage/go-ethstorage/issues/72).
2. issue 95: For the node which is new to the ethstorage network, it dials the nodes that do not contain the new node's ENR, so the nodes do not know the new node's shard list from ENR so that the connection will be close by the nodes and the new node may not be able to join the network until its ENR sync to those nodes. (issue https://github.com/ethstorage/go-ethstorage/issues/95)

**How to fix:**
1. issue 72 is caused by we enable the` libp2p.EnableNATService()` when creating a host, so a new dialerHost will be created as Auto NAT Service with a new Peer ID and address, see the following comments.
```
      // EnableNATService configures libp2p to provide a service to peers for determining
      // their reachability status. When enabled, the host will attempt to dial back
      // to peers, and then tell them if it was successful in making such connections.
```
So, for this kind of connection, the Peerstore does not contain its address (its addresses are saved in the dialerHost), so we can ignore this connection without closing it, it will be closed automatically.

2. For the node which is new to the ethstorage network, it dials the nodes that do not contain the new node's ENR, so the nodes do not know the new node's shard list from ENR so they need to call n.RequestShardList() to fetch the shard list of the new node and add it to Peerstore.

**How to test:**
Run nodes like the following command, one is bootnode and the other connects to it
`./es-node --network dev --p2p.listen.ip 147.182.142.140 --p2p.listen.udp 30303 --p2p.listen.tcp 9333 --p2p.advertise.ip 147.182.142.140 --l1.rpc http://65.109.50.145:32773 --l1.beacon http://65.109.50.145:32785 --storage.files storage.dat --storage.l1contract 0x8FA01287747B8f876C8bA532D9Bd48b73329c431 --storage.miner 0x5C935469C5592Aeeac3372e922d9bCEabDF8830d --storage.kv-size 131072  --storage.chunk-size 131072 --storage.kv-entries 256 --datadir ./database --download.start -2 --download.dump ../es-utils/compare  --log.level debug`
you can see logs like `write response done for HandleRequestShardList` in bootnode and `get remote shard list success` in the other node's log.
