### PR TITLE
bugfix -- do not RemovePeer for NAT conn

### DIFF
--- a/ethstorage/p2p/node.go
+++ b/ethstorage/p2p/node.go
@@ -130,7 +130,7 @@ func (n *NodeP2P) init(resourcesCtx context.Context, rollupCfg *rollup.EsConfig,
 			},
 			DisconnectedF: func(nw network.Network, conn network.Conn) {
 				if len(n.host.Peerstore().Addrs(conn.RemotePeer())) == 0 {
-					log.Debug("no addresses to get shard list, return without close conn", "peer", conn.RemotePeer())
+					log.Debug("no addresses in peer store, return without remove peer", "peer", conn.RemotePeer())
 					return
 				}
 				n.syncCl.RemovePeer(conn.RemotePeer())


### PR DESCRIPTION
We do not add peer to syncclient for NAT connection, so there is no need to removePeer for it. 

How to check: no warning like `cannot remove peer from sync duties, peer was not registered` for NAT peer.
```
INFO [09-29|03:38:14.171] connected to peer                        peer=12D3KooWFnc8XBam2a65k4HCc1S4ympF5uXv25ruV3AMzk1SbGRu addr=/ip4/159.223.128.53/tcp/36666
WARN [09-29|03:38:14.171] cannot remove peer from sync duties, peer was not registered peer=12D3KooWFnc8XBam2a65k4HCc1S4ympF5uXv25ruV3AMzk1SbGRu
INFO [09-29|03:38:14.171] disconnected from peer                   peer=12D3KooWFnc8XBam2a65k4HCc1S4ympF5uXv25ruV3AMzk1SbGRu addr=/ip4/159.223.128.53/tcp/36666

```