### PR TITLE
fix issue 8 -- show the sync progress by using log.Info to tell users the progress of filling empty and syncing

### DIFF
--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -171,6 +171,7 @@ type SyncClient struct {
 
 	prover         prv.IProver
 	startTime      time.Time // Time instance when sstorage sync started
+	logTime        time.Time // Time instance when status was last reported
 	storageManager StorageManager
 
 	blobsSynced      uint64
@@ -429,9 +430,9 @@ func (s *SyncClient) cleanTasks() {
 	if allDone {
 		s.setSyncDone()
 		log.Info("storage sync done", "subTask count", len(s.tasks))
+
+		s.report(true)
 	}
-	
-	s.report()
 }
 
 func (s *SyncClient) Start() {
@@ -503,7 +504,7 @@ func (s *SyncClient) Close() error {
 	s.wg.Wait()
 	s.cleanTasks()
 	s.saveSyncStatus()
-	s.report()
+	s.report(true)
 	return nil
 }
 
@@ -570,6 +571,8 @@ func (s *SyncClient) mainLoop() {
 			s.log.Info("stopped P2P req-resp L2 block sync client")
 			return
 		}
+		// Report stats if something meaningful happened
+		s.report(false)
 	}
 }
 
@@ -1079,7 +1082,13 @@ func (s *SyncClient) commitBlob(decodedBlob []byte, payload *BlobPayload) bool {
 }
 
 // report calculates various status reports and provides it to the user.
-func (s *SyncClient) report() {
+func (s *SyncClient) report(force bool) {
+	// Don't report all the events, just occasionally
+	if !force && time.Since(s.logTime) < 8*time.Second {
+		return
+	}
+	s.logTime = time.Now()
+
 	// Don't report anything until we have a meaningful progress
 	synced := s.blobsSynced
 	if synced == 0 {


### PR DESCRIPTION
fix issue 8: [p2p sync may need to show the progress by using log.Info to tell users the progress of filling empty and syncing](https://github.com/ethstorage/es-node/issues/8)

how to check: 
with this fix, logs like the following will regularly show.
`Sstorage sync in progress                synced=100.00% state=16384 kvsToSync=0 "sub subTask remain"=0 kv=16384@2.00GiB eta="-10.182µs" "empty KV filled"=0 "empty KV to fill"=0`