### PR TITLE
report sync state if empty blobs start filling

### DIFF
--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -1091,7 +1091,7 @@ func (s *SyncClient) report(force bool) {
 
 	// Don't report anything until we have a meaningful progress
 	synced := s.blobsSynced
-	if synced == 0 {
+	if synced == 0 && s.emptyBlobsFilled == 0 {
 		return
 	}
 	kvsToSync := uint64(0)


### PR DESCRIPTION
related issue: https://github.com/ethstorage/es-node/issues/8

verify: 
see logs like the following even if no blobs sync from the remote peers.
Sstorage sync in progress                synced=100.00% state=0 kvsToSync=0 "sub subTask remain"=0 kv=16384@2.00GiB eta="-10.182µs" "empty KV filled"=16 "empty KV to fill"=16368