### PR TITLE
bug fix - crash when report sync state at fill empty is start but no sync any blob yet.

### DIFF
--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -1097,7 +1097,7 @@ func (s *SyncClient) report(force bool) {
 		return
 	}
 	blobsToSync := uint64(0)
-	taskRemain, subTaskRemain := 0, 0
+	taskRemain, subTaskRemain, subFillTaskRemain := 0, 0, 0
 	for _, t := range s.tasks {
 		for _, st := range t.SubTasks {
 			blobsToSync = blobsToSync + (st.Last - st.next)
@@ -1107,6 +1107,7 @@ func (s *SyncClient) report(force bool) {
 		if !t.done {
 			taskRemain++
 		}
+		subFillTaskRemain = subFillTaskRemain + len(t.SubEmptyTasks)
 	}
 
 	elapsed := time.Since(s.startTime)
@@ -1120,7 +1121,7 @@ func (s *SyncClient) report(force bool) {
 		blobsFilled     = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(emptyFilled), filledBytes.TerminalString())
 	)
 	log.Info("Storage sync in progress", "progress", progress, "syncTasksRemain", syncTasksRemain,
-		"blobsSynced", blobsSynced, "blobsToSync", blobsToSync,
+		"blobsSynced", blobsSynced, "blobsToSync", blobsToSync, "fillTasksRemain", subFillTaskRemain,
 		"emptyFilled", blobsFilled, "emptyToFill", emptyToFill, "eta", common.PrettyDuration(estTime-elapsed))
 }
 


### PR DESCRIPTION
fix the bug and change the report format as follows:

`INFO [10-12|16:46:15.236] Storage sync in progress                 progress=2.34% syncTasksRemain=1@16 blobsSynced=0@0.00B blobsToSync=1041 fillTasksRemain=6 emptyFilled=192@24.00MiB emptyToFill=6959 eta=41m20.193s`


