### PR TITLE
add profile to ethstorage

### DIFF
--- a/cmd/es-node/config.go
+++ b/cmd/es-node/config.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"os"
 
+	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
@@ -94,11 +95,11 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		// 		ListenAddr: ctx.GlobalString(flags.MetricsAddrFlag.Name),
 		// 		ListenPort: ctx.GlobalInt(flags.MetricsPortFlag.Name),
 		// 	},
-		// 	Pprof: oppprof.CLIConfig{
-		// 		Enabled:    ctx.GlobalBool(flags.PprofEnabledFlag.Name),
-		// 		ListenAddr: ctx.GlobalString(flags.PprofAddrFlag.Name),
-		// 		ListenPort: ctx.GlobalInt(flags.PprofPortFlag.Name),
-		// 	},
+		Pprof: oppprof.CLIConfig{
+			Enabled:    ctx.GlobalBool(flags.PprofEnabledFlag.Name),
+			ListenAddr: ctx.GlobalString(flags.PprofAddrFlag.Name),
+			ListenPort: ctx.GlobalInt(flags.PprofPortFlag.Name),
+		},
 		P2P: p2pConfig,
 		// 	P2PSigner:           p2pSignerSetup,
 		L1EpochPollInterval: ctx.GlobalDuration(flags.L1EpochPollIntervalFlag.Name),

--- a/cmd/es-node/main.go
+++ b/cmd/es-node/main.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"net"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 
+	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
@@ -113,7 +116,16 @@ func EsNodeMain(ctx *cli.Context) error {
 	defer n.Close()
 
 	// TODO: heartbeat
-	// TODO: pprof
+	if cfg.Pprof.Enabled {
+		pprofCtx, pprofCancel := context.WithCancel(context.Background())
+		go func() {
+			log.Info("pprof server started", "addr", net.JoinHostPort(cfg.Pprof.ListenAddr, strconv.Itoa(cfg.Pprof.ListenPort)))
+			if err := oppprof.ListenAndServe(pprofCtx, cfg.Pprof.ListenAddr, cfg.Pprof.ListenPort); err != nil {
+				log.Error("error starting pprof", "err", err)
+			}
+		}()
+		defer pprofCancel()
+	}
 
 	log.Info("Storage node started")
 

--- a/ethstorage/flags/flags.go
+++ b/ethstorage/flags/flags.go
@@ -87,6 +87,23 @@ var (
 		Usage:  "Enable metrics",
 		EnvVar: prefixEnvVar("METRICS_ENABLE"),
 	}
+	PprofEnabledFlag = cli.BoolFlag{
+		Name:   "pprof.enabled",
+		Usage:  "Enable the pprof server",
+		EnvVar: prefixEnvVar("PPROF_ENABLED"),
+	}
+	PprofAddrFlag = cli.StringFlag{
+		Name:   "pprof.addr",
+		Usage:  "pprof listening address",
+		Value:  "0.0.0.0",
+		EnvVar: prefixEnvVar("PPROF_ADDR"),
+	}
+	PprofPortFlag = cli.IntFlag{
+		Name:   "pprof.port",
+		Usage:  "pprof listening port",
+		Value:  6060,
+		EnvVar: prefixEnvVar("PPROF_PORT"),
+	}
 	DownloadStart = cli.Int64Flag{
 		Name:   "download.start",
 		Usage:  "Block number which the downloader download blobs from",
@@ -183,6 +200,9 @@ var optionalFlags = []cli.Flag{
 	L1MinDurationForBlobsRequest,
 	L2ChainId,
 	MetricsEnable,
+	PprofEnabledFlag,
+	PprofAddrFlag,
+	PprofPortFlag,
 	DownloadStart,
 	DownloadDump,
 	L1EpochPollIntervalFlag,

--- a/ethstorage/node/config.go
+++ b/ethstorage/node/config.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
 	"github.com/ethstorage/go-ethstorage/ethstorage/db"
 	"github.com/ethstorage/go-ethstorage/ethstorage/downloader"
 	"github.com/ethstorage/go-ethstorage/ethstorage/eth"
@@ -42,7 +43,7 @@ type Config struct {
 
 	// Metrics MetricsConfig
 
-	// Pprof oppprof.CLIConfig
+	Pprof oppprof.CLIConfig
 
 	// Used to poll the L1 for new finalized or safe blocks
 	L1EpochPollInterval time.Duration
@@ -73,9 +74,9 @@ func (cfg *Config) Check() error {
 	// if err := cfg.Metrics.Check(); err != nil {
 	// 	return fmt.Errorf("metrics config error: %w", err)
 	// }
-	// if err := cfg.Pprof.Check(); err != nil {
-	// 	return fmt.Errorf("pprof config error: %w", err)
-	// }
+	if err := cfg.Pprof.Check(); err != nil {
+		return fmt.Errorf("pprof config error: %w", err)
+	}
 	if cfg.P2P != nil {
 		if err := cfg.P2P.Check(); err != nil {
 			return fmt.Errorf("p2p config error: %w", err)


### PR DESCRIPTION
Add profile params to command to enable debugging and analysis the memory or CPU usage of es-node

How to use it:
Add  `--pprof.addr` `--pprof.port` `--pprof.enabled` to enable and set the profile address or port.
`--network devnet --datadir ./database --storage.files storage.dat --l1.beacon http://65.108.236.27:5052  --l1.rpc http://65.108.236.27:8545 --storage.l1contract 0x882BC290fc22C330592819977c48968a62AE25f4 --storage.miner 0x5C935469C5592Aeeac3372e922d9bCEabDF8830d --l1.beacon-based-time 1695981612 --l1.beacon-based-slot 1 --p2p.listen.udp 30305 --log.level debug --pprof.addr 127.0.0.1 --pprof.enabled  --p2p.bootnodes enr:-Li4QPWz6DaLXwZ3vgUfx5i0M6ysMAhjlFrkLlzaKdvbMykrIzdncYXQG0rjF8anZfv65LpEuYVdOZPbjzwvthqUIq-GAYsoHnk0imV0aHN0b3JhZ2XbAYDY15SIK8KQ_CLDMFkoGZd8SJaKYq4l9MGAgmlkgnY0gmlwhEFs7BuJc2VjcDI1NmsxoQI2rSdv0CGNPia7uQgvYdt4XuW2Nkp062a0jsr-H-SJ4IN0Y3CCJAaDdWRwgnZh`

How to verify it:
After the node starts, you can see the profile info from `http://<address>:<port>/debug/pprof/`, download profile from  `http://<address>:<port>/debug/pprof/profile` and open it using the following command:
`go tool pprof -http=:8080 profile`

