### PR TITLE
add make file to make the built es-node versoin contain 

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -98,8 +98,7 @@ npm install -g snarkjs@0.7.0
 ```
 #### 4. Build es-node
 ```sh
-echo VERSION_META would be stable/beta/alpha/dev.
-export VERSION_META=dev && make 
+make 
 ```
 #### 5. Start es-node
 ```sh

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -98,7 +98,8 @@ npm install -g snarkjs@0.7.0
 ```
 #### 4. Build es-node
 ```sh
-cd cmd/es-node && go build && cd ../..
+echo VERSION_META would be stable/beta/alpha/dev.
+export VERSION_META=dev && make 
 ```
 #### 5. Start es-node
 ```sh

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILDDATE := $(shell date)
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
 LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
 LDFLAGSSTRING +=-X main.Meta=$(VERSION_META)
-LDFLAGSSTRING +=-X main.BuildTime=$(BUILDDATE)
+LDFLAGSSTRING +=-X 'main.BuildTime=$(BUILDDATE)'
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
 es-node:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ BUILDDATE := $(shell date)
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
 LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
+LDFLAGSSTRING +=-X main.Meta=$(VERSION_META)
 LDFLAGSSTRING +=-X 'main.BuildTime=$(BUILDDATE)'
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+GITCOMMIT := $(shell git rev-parse HEAD)
+GITDATE := $(shell git show -s --format='%ct')
+VERSION := v0.1.1
+VERSION_META := dev
+
+LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
+LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
+LDFLAGSSTRING +=-X main.Version=$(VERSION)
+LDFLAGSSTRING +=-X main.Meta=$(VERSION_META)
+LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
+
+es-node:
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./cmd/es-node/es-node ./cmd/es-node/
+
+clean:
+	rm ./cmd/es-node/es-node
+
+test:
+	go test -v ./...
+
+lint:
+	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint -e "errors.As" -e "errors.Is"
+
+
+.PHONY: \
+	es-node \
+	clean \
+	test \
+	lint

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,8 @@
 GITCOMMIT := $(shell git rev-parse HEAD)
 GITDATE := $(shell git show -s --format='%ct')
-VERSION := v0.1.1
-VERSION_META := dev
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
 LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
-LDFLAGSSTRING +=-X main.Version=$(VERSION)
 LDFLAGSSTRING +=-X main.Meta=$(VERSION_META)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ BUILDDATE := $(shell date)
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
 LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
-LDFLAGSSTRING +=-X main.Meta=$(VERSION_META)
 LDFLAGSSTRING +=-X 'main.BuildTime=$(BUILDDATE)'
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 GITCOMMIT := $(shell git rev-parse HEAD)
 GITDATE := $(shell git show -s --format='%ct')
+BUILDDATE := $(shell date)
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
 LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
 LDFLAGSSTRING +=-X main.Meta=$(VERSION_META)
+LDFLAGSSTRING +=-X main.BuildTime=$(BUILDDATE)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
 es-node:

--- a/cmd/es-node/main.go
+++ b/cmd/es-node/main.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -25,10 +26,13 @@ import (
 )
 
 var (
-	GitCommit = ""
-	GitDate   = ""
-	Version   = "v0.1.1"
-	Meta      = "dev"
+	GitCommit     = ""
+	GitDate       = ""
+	Version       = "v0.1.1"
+	Meta          = "dev"
+	BuildTime     = ""
+	systemVersion = fmt.Sprintf("%s/%s", runtime.GOARCH, runtime.GOOS)
+	golangVersion = runtime.Version()
 )
 
 // VersionWithMeta holds the textual version string including the metadata.
@@ -46,13 +50,19 @@ var VersionWithMeta = func() string {
 	return v
 }()
 
+var BuildInfo = func() string {
+	return fmt.Sprintf(
+		"%s\nbuild date: %s\nsystem version: %s\ngolang version: %s",
+		VersionWithMeta, BuildTime, systemVersion, golangVersion)
+}()
+
 func main() {
 	// Set up logger with a default INFO level in case we fail to parse flags,
 	// otherwise the final critical log won't show what the parsing error was.
 	eslog.SetupDefaults()
 
 	app := cli.NewApp()
-	app.Version = VersionWithMeta
+	app.Version = BuildInfo
 	app.Flags = flags.Flags
 	app.Name = "es-node"
 	app.Usage = "EthStorage Storage Node"

--- a/cmd/es-node/main.go
+++ b/cmd/es-node/main.go
@@ -52,7 +52,7 @@ var VersionWithMeta = func() string {
 
 var BuildInfo = func() string {
 	return fmt.Sprintf(
-		"%s\nbuild date: %s\nsystem version: %s\ngolang version: %s",
+		"%s\nBuild date: %s\nSystem version: %s\nGolang version: %s",
 		VersionWithMeta, BuildTime, systemVersion, golangVersion)
 }()
 
@@ -64,7 +64,7 @@ func main() {
 	app := cli.NewApp()
 	app.Version = BuildInfo
 	app.Flags = flags.Flags
-	app.Name = "es-node"
+	app.Name = "EthStorage node"
 	app.Usage = "EthStorage Storage Node"
 	app.Description = "The EthStorage Storage Node derives L2 datahashes of the values of KV store from L1 data and reconstructs the values via L1 DA and ES P2P network."
 	app.Action = EsNodeMain


### PR DESCRIPTION
Related issue: https://github.com/ethstorage/es-node/issues/54

New build:
```
root@goquarkchain-test:~/github.com/ethstorage/es-node# make 
env GO111MODULE=on GOOS= GOARCH= go1.20.10 build -v -ldflags "-X main.GitCommit=eeff04cbffb524bda291abd7006d2b98c43ccbf9 -X main.GitDate=1699671584 -X main.Meta=dev -X 'main.BuildTime=Sat Nov 11 03:03:05 UTC 2023'" -o ./cmd/es-node/es-node ./cmd/es-node/
github.com/ethstorage/go-ethstorage/cmd/es-node
root@goquarkchain-test:~/github.com/ethstorage/es-node# ./cmd/es-node/es-node -v
EthStorage node version v0.1.1-81e083e9-1699873072
Build date: Mon Nov 13 10:59:47 UTC 2023
System version: amd64/linux
Golang version: go1.20.10
```
