### PR TITLE
remove mplex which block Upgrade libp2p to v0.32.0

### DIFF
--- a/ethstorage/flags/p2p_flags.go
+++ b/ethstorage/flags/p2p_flags.go
@@ -138,10 +138,10 @@ var (
 	}
 	HostMux = cli.StringFlag{
 		Name:     "p2p.mux",
-		Usage:    "Comma-separated list of multiplexing protocols in order of preference. At least 1 required. Options: 'yamux','mplex'.",
+		Usage:    "Comma-separated list of multiplexing protocols in order of preference. At least 1 required. Options: 'yamux'.",
 		Hidden:   true,
 		Required: false,
-		Value:    "yamux,mplex",
+		Value:    "yamux",
 		EnvVar:   p2pEnv("MUX"),
 	}
 	HostSecurity = cli.StringFlag{

--- a/ethstorage/p2p/cli/load_config.go
+++ b/ethstorage/p2p/cli/load_config.go
@@ -245,8 +245,6 @@ func loadLibp2pOpts(conf *p2p.Config, ctx *cli.Context) error {
 		switch v {
 		case "yamux":
 			conf.HostMux = append(conf.HostMux, p2p.YamuxC())
-		case "mplex":
-			conf.HostMux = append(conf.HostMux, p2p.MplexC())
 		default:
 			return fmt.Errorf("could not recognize mux %s", v)
 		}

--- a/ethstorage/p2p/host.go
+++ b/ethstorage/p2p/host.go
@@ -17,7 +17,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/sec/insecure"
 	basichost "github.com/libp2p/go-libp2p/p2p/host/basic"
 	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoreds"
-	"github.com/libp2p/go-libp2p/p2p/muxer/mplex"
 	"github.com/libp2p/go-libp2p/p2p/muxer/yamux"
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
 	tls "github.com/libp2p/go-libp2p/p2p/security/tls"
@@ -248,9 +247,6 @@ func YamuxC() libp2p.Option {
 	return libp2p.Muxer("/yamux/1.0.0", yamux.DefaultTransport)
 }
 
-func MplexC() libp2p.Option {
-	return libp2p.Muxer("/mplex/6.7.0", mplex.DefaultTransport)
-}
 
 func NoiseC() libp2p.Option {
 	return libp2p.Security(noise.ID, noise.New)


### PR DESCRIPTION
Related issue: https://github.com/ethstorage/es-node/issues/65

remove mplex transport which has been deprecated by libp2p.

how to test: 
run the node to sync blobs.