### PR TITLE
Cache blob metas and lastKvIndex before blob syncing to improve the performance of p2p syncing

### DIFF
--- a/ethstorage/downloader/downloader.go
+++ b/ethstorage/downloader/downloader.go
@@ -30,11 +30,11 @@ const (
 	TrackSafe            // 1
 	TrackFinalized       // 2
 
-	downloadBatchSize = 64 // 2 epoch	
+	downloadBatchSize = 64 // 2 epoch
 )
 
 var (
-	downloaderPrefix  = []byte("dl-") 
+	downloaderPrefix  = []byte("dl-")
 	lastDownloadKey = []byte("last-download-block")
 )
 
@@ -53,10 +53,10 @@ type Downloader struct {
 	latestHead                 int64
 	dumpDir                    string
 	minDurationForBlobsRequest uint64
-	
+
 	// Request to download new blobs
 	dlLatestReq                chan struct{}
-	dlFinalizedReq             chan struct{}	
+	dlFinalizedReq             chan struct{}
 
 	log                        log.Logger
 	done                       chan struct{}
@@ -80,11 +80,11 @@ type blockBlobs struct {
 
 
 func NewDownloader(
-	l1Source *eth.PollingClient, 
+	l1Source *eth.PollingClient,
 	l1Beacon *eth.BeaconClient,
 	db ethdb.Database,
-	sm *ethstorage.StorageManager, 
-	downloadStart int64, 
+	sm *ethstorage.StorageManager,
+	downloadStart int64,
 	downloadDump  string,
 	minDurationForBlobsRequest uint64,
 	downloadThreadNum int,
@@ -92,7 +92,7 @@ func NewDownloader(
 ) *Downloader{
 	sm.DownloadThreadNum = downloadThreadNum
 	return &Downloader{
-		Cache: NewBlobCache(),		
+		Cache: NewBlobCache(),
 		l1Source: l1Source,
 		l1Beacon: l1Beacon,
 		db: db,
@@ -108,7 +108,7 @@ func NewDownloader(
 }
 
 // Start starts up the state loop.
-func (s *Downloader) Start() error {	
+func (s *Downloader) Start() error {
 	// user does NOT specify a download start in the flag
 	if s.lastDownloadBlock == 0 {
 		bs, err := s.db.Get(append(downloaderPrefix, lastDownloadKey...))
@@ -138,7 +138,10 @@ func (s *Downloader) Start() error {
 		}
 	}
 
-	s.sm.Reset(s.lastDownloadBlock)
+	err := s.sm.Reset(s.lastDownloadBlock)
+	if err != nil {
+		return err
+	}
 
 	s.wg.Add(1)
 	go s.eventLoop()
@@ -158,7 +161,7 @@ func (s *Downloader) OnL1Finalized(finalized uint64) {
 	}
 	s.finalizedHead = int64(finalized)
 	s.mu.Unlock()
-	
+
 	select {
 	case s.dlFinalizedReq <- struct{}{}:
 		return
@@ -169,7 +172,7 @@ func (s *Downloader) OnL1Finalized(finalized uint64) {
 }
 
 func (s *Downloader) OnNewL1Head(head eth.L1BlockRef) {
-	s.mu.Lock()	
+	s.mu.Lock()
 	if s.latestHead > int64(head.Number) {
 		s.log.Info("The tracking head is greater than new one, a reorg may happen", "tracking", s.latestHead, "new", head)
 	}
@@ -209,7 +212,7 @@ func (s *Downloader) downloadToCache() {
 		return
 	}
 	end := s.latestHead
-	start := s.lastCacheBlock 
+	start := s.lastCacheBlock
 	if start == 0 {
 		start = s.finalizedHead
 	}
@@ -218,7 +221,7 @@ func (s *Downloader) downloadToCache() {
 	// @Qiang devnet-4 have issues to get blob event for the latest block, so if we need roll back to devnet-4
 	// we may need to change it to s.downloadRange(start, end, true)
 	_, err := s.downloadRange(start + 1, end, true)
-	
+
 	if err == nil {
 		s.lastCacheBlock = end
 	} else {
@@ -233,7 +236,7 @@ func (s *Downloader) download() {
 
 	if (s.lastDownloadBlock > 0) && (trackHead - s.lastDownloadBlock > int64(s.minDurationForBlobsRequest)) {
 		// TODO: @Qiang we can also enter into an recovery mode (e.g., scan local blobs to obtain a heal list, more complicated, will do later)
-		prompt := "Ethereum only keep blobs for one month, but it has been over one month since last blob download." + 
+		prompt := "Ethereum only keep blobs for one month, but it has been over one month since last blob download." +
 			"You may need to restart this node with full re-sync"
 		s.log.Error(prompt)
 		return
@@ -270,14 +273,14 @@ func (s *Downloader) download() {
 			// save lastDownloadedBlock into database
 			bs := make([]byte, 8)
 			binary.LittleEndian.PutUint64(bs, uint64(end))
-		
+
 			err = s.db.Put(append(downloaderPrefix, lastDownloadKey...), bs)
 			if err != nil {
 				s.log.Error("Save lastDownloadedBlock into db error", "err", err)
 				return
 			}
 			s.log.Info("LastDownloadedBlock saved into db", "lastDownloadedBlock", end)
-		
+
 			s.dumpBlobsIfNeeded(blobs)
 
 			s.lastDownloadBlock = end
@@ -288,17 +291,17 @@ func (s *Downloader) download() {
 	s.Cache.Cleanup(uint64(trackHead))
 }
 
-// The entire downloading process consists of two phases: 
+// The entire downloading process consists of two phases:
 // 1. Downloading the blobs into the cache when they are not finalized, with the option toCache set to true.
 // 2. Writing the blobs into the shard file when they are finalized, with the option toCache set to false.
 // we will attempt to read the blobs from the cache initially. If they don't exist in the cache, we will download them instead.
 func (s *Downloader) downloadRange(start int64, end int64, toCache bool) ([]blob, error) {
 	ts := time.Now()
-	
+
 	if end < start {
 		end = start
 	}
-	
+
 	events, err := s.l1Source.FilterLogsByBlockRange(big.NewInt(int64(start)), big.NewInt(int64(end)))
 	if err != nil {
 		return nil, err
@@ -306,7 +309,7 @@ func (s *Downloader) downloadRange(start int64, end int64, toCache bool) ([]blob
 	elBlocks, err := s.eventsToBlocks(events)
 	if err != nil {
 		return nil, err
-	}	
+	}
 	blobs := []blob{}
 	for _, elBlock := range elBlocks {
 		// attempt to read the blobs from the cache first
@@ -317,22 +320,22 @@ func (s *Downloader) downloadRange(start int64, end int64, toCache bool) ([]blob
 			continue
 		} else {
 			s.log.Info(
-				"Don't find blob in the cache, will try to download directly", 
-				"blockNumber", elBlock.number, 
-				"start", start, 
+				"Don't find blob in the cache, will try to download directly",
+				"blockNumber", elBlock.number,
+				"start", start,
 				"end", end,
 				"toCache", toCache,
 			)
 		}
-		
+
 		clBlobs, err := s.l1Beacon.DownloadBlobs(s.l1Beacon.Timestamp2Slot(elBlock.timestamp))
 		if err != nil {
 			s.log.Error("L1 beacon download blob error", "err", err)
 			return nil, err
 		}
-		
+
 		for _, elBlob := range elBlock.blobs {
-			clBlob, exists := clBlobs[elBlob.hash]; 
+			clBlob, exists := clBlobs[elBlob.hash];
 			if !exists {
 				s.log.Error("Did not find the event specified blob in the CL")
 
@@ -344,7 +347,7 @@ func (s *Downloader) downloadRange(start int64, end int64, toCache bool) ([]blob
 			s.Cache.SetBlockBlobs(elBlock)
 		}
 	}
-	
+
 	s.log.Info("Download range", "cache", toCache, "start", start, "end", end, "blobNumber", len(blobs), "duration(ms)", time.Since(ts).Milliseconds())
 
 	return blobs, nil
@@ -352,7 +355,7 @@ func (s *Downloader) downloadRange(start int64, end int64, toCache bool) ([]blob
 
 func (s *Downloader) dumpBlobsIfNeeded(blobs []blob) {
 	if s.dumpDir != "" {
-		for _, blob := range blobs {			
+		for _, blob := range blobs {
 			fileName := filepath.Join(s.dumpDir, fmt.Sprintf("%s.dat", hex.EncodeToString(blob.data[:5])))
 			f, err := os.Create(fileName)
 			if err != nil {
@@ -360,7 +363,7 @@ func (s *Downloader) dumpBlobsIfNeeded(blobs []blob) {
 				return
 			}
 			defer f.Close()
-		
+
 			writer := bufio.NewWriter(f)
 			writer.WriteString(string(blob.data))
 			writer.Flush()
@@ -384,13 +387,13 @@ func (s *Downloader) eventsToBlocks(events []types.Log) ([]*blockBlobs, error) {
 				number: event.BlockNumber,
 				hash: event.BlockHash,
 				blobs: []*blob{},
-			}) 
+			})
 		}
 
 		block := blocks[len(blocks) - 1]
 		hash := common.Hash{}
 		copy(hash[:], event.Topics[3][:])
-		
+
 		blob := blob{
 			kvIndex: big.NewInt(0).SetBytes(event.Topics[1][:]),
 			kvSize: big.NewInt(0).SetBytes(event.Topics[2][:]),

--- a/ethstorage/flags/p2p_flags.go
+++ b/ethstorage/flags/p2p_flags.go
@@ -169,6 +169,13 @@ var (
 		Value:    16,
 		EnvVar:   p2pEnv("MAX_CONCURRENCY"),
 	}
+	MetaDownloadBatchSize = cli.Uint64Flag{
+		Name: "p2p.meta.download.batch",
+		Usage: "Batch size for requesting the blob metadatas stored in the storage contract in one RPC call.",
+		Required: false,
+		Value:    8000, // The upper limit of devnet-11 geth node
+		EnvVar:   p2pEnv("META_BATCH_SIZE"),
+	}
 	PeersLo = cli.UintFlag{
 		Name:     "p2p.peers.lo",
 		Usage:    "Low-tide peer count. The node actively searches for new peer connections if below this amount.",
@@ -332,6 +339,7 @@ var p2pFlags = []cli.Flag{
 	HostSecurity,
 	MaxRequestSize,
 	MaxConcurrency,
+	MetaDownloadBatchSize,
 	PeersLo,
 	PeersHi,
 	PeersGrace,

--- a/ethstorage/node/node.go
+++ b/ethstorage/node/node.go
@@ -210,7 +210,7 @@ func (n *EsNode) initStorageManager(ctx context.Context, cfg *Config) error {
 		"chunkSize", shardManager.ChunkSize(),
 		"kvsPerShard", shardManager.KvEntries())
 
-	n.storageManager = ethstorage.NewStorageManager(shardManager, n.l1Source)
+	n.storageManager = ethstorage.NewStorageManager(shardManager, n.l1Source, cfg.P2P.SyncerParams().MetaDownloadBatchSize)
 	return nil
 }
 

--- a/ethstorage/node/node.go
+++ b/ethstorage/node/node.go
@@ -210,7 +210,7 @@ func (n *EsNode) initStorageManager(ctx context.Context, cfg *Config) error {
 		"chunkSize", shardManager.ChunkSize(),
 		"kvsPerShard", shardManager.KvEntries())
 
-	n.storageManager = ethstorage.NewStorageManager(shardManager, n.l1Source, cfg.P2P.SyncerParams().MetaDownloadBatchSize)
+	n.storageManager = ethstorage.NewStorageManager(shardManager, n.l1Source)
 	return nil
 }
 

--- a/ethstorage/node/node.go
+++ b/ethstorage/node/node.go
@@ -252,7 +252,11 @@ func (n *EsNode) Start(ctx context.Context, cfg *Config) error {
 		return err
 	}
 
-	n.p2pNode.Start()
+	if err := n.p2pNode.Start(); err != nil {
+		n.log.Error("Could not start a p2pNode", "err", err)
+		return err
+	}
+
 	return nil
 }
 

--- a/ethstorage/node/node_mine_test.go
+++ b/ethstorage/node/node_mine_test.go
@@ -187,10 +187,7 @@ func fillEmpty(t *testing.T, n *EsNode, contract common.Address) {
 		t.Fatalf("Failed to get block number %v", err)
 	}
 	n.storageManager.Reset(int64(block))
-	lastBlobIdx, err := n.storageManager.LastKvIndex()
-	if err != nil {
-		t.Fatalf("get lastBlobIdx for FillEmptyKV fail, err: %s", err.Error())
-	}
+	lastBlobIdx := n.storageManager.LastKvIndex()
 	limit := n.storageManager.KvEntries() * uint64(len(shardIds))
 	for idx := lastBlobIdx; idx < limit; idx++ {
 		err = n.storageManager.CommitBlob(idx, empty, common.Hash{})

--- a/ethstorage/p2p/cli/load_config.go
+++ b/ethstorage/p2p/cli/load_config.go
@@ -362,11 +362,12 @@ func loadGossipOptions(conf *p2p.Config, ctx *cli.Context) error {
 
 // loadSyncerParams loads [protocol.SyncerParams] from the CLI context.
 func loadSyncerParams(conf *p2p.Config, ctx *cli.Context) error {
+	metaDownloadBatchSize := ctx.GlobalUint64(flags.MetaDownloadBatchSize.Name)
 	maxRequestSize := ctx.GlobalUint64(flags.MaxRequestSize.Name)
 	maxConcurrency := ctx.GlobalUint64(flags.MaxConcurrency.Name)
 	if maxConcurrency < 1 {
 		return fmt.Errorf("p2p.max.concurrency param is invalid: the value should larger than 0")
 	}
-	conf.SyncParams = &protocol.SyncerParams{MaxRequestSize: maxRequestSize, MaxConcurrency: maxConcurrency}
+	conf.SyncParams = &protocol.SyncerParams{MaxRequestSize: maxRequestSize, MaxConcurrency: maxConcurrency, MetaDownloadBatchSize: metaDownloadBatchSize}
 	return nil
 }

--- a/ethstorage/p2p/node.go
+++ b/ethstorage/p2p/node.go
@@ -234,8 +234,8 @@ func (n *NodeP2P) ConnectionManager() connmgr.ConnManager {
 	return n.connMgr
 }
 
-func (n *NodeP2P) Start() {
-	n.syncCl.Start()
+func (n *NodeP2P) Start() error {
+	return n.syncCl.Start()
 }
 
 func (n *NodeP2P) Close() error {

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -129,9 +129,11 @@ type StorageManager interface {
 
 	StorageManagerWriter
 
-	LastKvIndex() (uint64, error)
+	LastKvIndex() uint64
 
 	DecodeKV(kvIdx uint64, b []byte, hash common.Hash, providerAddr common.Address, encodeType uint64) ([]byte, bool, error)
+
+	DownloadAllMetas() error
 }
 
 type SyncClient struct {
@@ -277,12 +279,7 @@ func (s *SyncClient) loadSyncStatus() {
 	}
 
 	// create tasks
-	lastKvIndex, err := s.storageManager.LastKvIndex()
-	if err != nil {
-		// TODO: panic?
-		log.Info("LoadSyncStatus failed: get lastKvIdx")
-		lastKvIndex = 0
-	}
+	lastKvIndex := s.storageManager.LastKvIndex()
 	for _, sid := range s.storageManager.Shards() {
 		exist := false
 		for _, task := range progress.Tasks {
@@ -448,7 +445,7 @@ func (s *SyncClient) cleanTasks() {
 	}
 }
 
-func (s *SyncClient) Start() {
+func (s *SyncClient) Start() error {
 	if s.startTime == (time.Time{}) {
 		s.startTime = time.Now()
 		s.logTime = time.Now()
@@ -456,9 +453,18 @@ func (s *SyncClient) Start() {
 
 	// Retrieve the previous sync status from LevelDB and abort if already synced
 	s.loadSyncStatus()
+	s.cleanTasks()
+	if !s.syncDone {
+		err := s.storageManager.DownloadAllMetas()
+		if err != nil {
+			return err
+		}
+	}
 
 	s.wg.Add(1)
 	go s.mainLoop()
+
+	return nil
 }
 
 func (s *SyncClient) AddPeer(id peer.ID, shards map[common.Address][]uint64) bool {
@@ -999,14 +1005,12 @@ func (s *SyncClient) FillFileWithEmptyBlob(start, limit uint64) (uint64, error) 
 		next     = start
 	)
 	defer s.metrics.ClientFillEmptyBlobsEvent(inserted, time.Since(st))
-	lastBlobIdx, err := s.storageManager.LastKvIndex()
-	if err != nil {
-		return start, fmt.Errorf("get lastBlobIdx for FillEmptyKV fail, err: %s", err.Error())
-	}
+	lastBlobIdx := s.storageManager.LastKvIndex()
+
 	if start < lastBlobIdx {
 		start = lastBlobIdx
 	}
-	inserted, next, err = s.storageManager.CommitEmptyBlobs(start, limit)
+	inserted, next, err := s.storageManager.CommitEmptyBlobs(start, limit)
 
 	return next, err
 }

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -453,13 +453,6 @@ func (s *SyncClient) Start() error {
 
 	// Retrieve the previous sync status from LevelDB and abort if already synced
 	s.loadSyncStatus()
-	s.cleanTasks()
-	if !s.syncDone {
-		err := s.storageManager.DownloadAllMetas()
-		if err != nil {
-			return err
-		}
-	}
 
 	s.wg.Add(1)
 	go s.mainLoop()
@@ -567,6 +560,15 @@ func (s *SyncClient) RequestL2List(indexes []uint64) (uint64, error) {
 
 func (s *SyncClient) mainLoop() {
 	defer s.wg.Done()
+
+	s.cleanTasks()
+	if !s.syncDone {
+		err := s.storageManager.DownloadAllMetas()
+		if err != nil {
+			log.Error("Download blob metadata failed", "error", err)
+			return
+		}
+	}
 
 	for {
 		// Remove all completed tasks and terminate sync if everything's done

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -133,7 +133,7 @@ type StorageManager interface {
 
 	DecodeKV(kvIdx uint64, b []byte, hash common.Hash, providerAddr common.Address, encodeType uint64) ([]byte, bool, error)
 
-	DownloadAllMetas() error
+	DownloadAllMetas(batchSize uint64) error
 }
 
 type SyncClient struct {
@@ -563,7 +563,7 @@ func (s *SyncClient) mainLoop() {
 
 	s.cleanTasks()
 	if !s.syncDone {
-		err := s.storageManager.DownloadAllMetas()
+		err := s.storageManager.DownloadAllMetas(s.syncerParams.MetaDownloadBatchSize)
 		if err != nil {
 			log.Error("Download blob metadata failed", "error", err)
 			return

--- a/ethstorage/p2p/protocol/types.go
+++ b/ethstorage/p2p/protocol/types.go
@@ -135,6 +135,7 @@ type EthStorageSyncDone struct {
 }
 
 type SyncerParams struct {
-	MaxRequestSize uint64
-	MaxConcurrency uint64
+	MaxRequestSize        uint64
+	MaxConcurrency        uint64
+	MetaDownloadBatchSize uint64
 }

--- a/ethstorage/storage_manager.go
+++ b/ethstorage/storage_manager.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"sync"
 	"time"
@@ -409,6 +410,7 @@ func (s *StorageManager) downloadMetaInParallel(from, to uint64) error {
 }
 
 func (s *StorageManager) downloadMetaInRange(from, to uint64, taskId uint64) error {
+	rangeStart := from
 	for from < to {
 		batchLimit := from + MetaBatchSize
 		if batchLimit > to {
@@ -442,7 +444,12 @@ func (s *StorageManager) downloadMetaInRange(from, to uint64, taskId uint64) err
 		}
 		s.mu.Unlock()
 
-		log.Info("One batch metas has been downloaded", "first", from, "batchLimit", batchLimit, "to", to, "taskId", taskId)
+		log.Info(
+			"One batch metas has been downloaded", "first", from,
+			"batchLimit", batchLimit,
+			"to", to,
+			"progress", fmt.Sprintf("%.1f%%", float64((from - rangeStart)*100)/float64(to - rangeStart)),
+			"taskId", taskId)
 
 		from = batchLimit
 	}

--- a/ethstorage/storage_manager.go
+++ b/ethstorage/storage_manager.go
@@ -405,7 +405,11 @@ func (s *StorageManager) downloadMetaInRange(from, to uint64, l1 int64, taskId u
 
 		metas, err := s.l1Source.GetKvMetas(kvIndices, l1)
 		if err != nil {
-			return err
+			// Retry the request again in case it could fail occasionally in poor network connection
+			metas, err = s.l1Source.GetKvMetas(kvIndices, l1)
+			if err != nil {
+				return err
+			}
 		}
 
 		s.metaMapMu.Lock()

--- a/ethstorage/storage_manager.go
+++ b/ethstorage/storage_manager.go
@@ -74,13 +74,6 @@ func (s *StorageManager) DownloadFinished(newL1 int64, kvIndices []uint64, blobs
 		return errors.New("new L1 is older than local L1")
 	}
 
-	lastKvIdx, err := s.l1Source.GetStorageLastBlobIdx(newL1)
-	if err != nil {
-		s.mu.Unlock()
-		return err
-	}
-	s.lastKvIdx = lastKvIdx
-
 	taskNum := s.DownloadThreadNum
 	var wg sync.WaitGroup
 	chanRes := make(chan error, taskNum)
@@ -128,6 +121,12 @@ func (s *StorageManager) DownloadFinished(newL1 int64, kvIndices []uint64, blobs
 		}
 	}
 
+	lastKvIdx, err := s.l1Source.GetStorageLastBlobIdx(newL1)
+	if err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	s.lastKvIdx = lastKvIdx
 	s.localL1 = newL1
 
 	s.mu.Unlock()

--- a/ethstorage/storage_manager.go
+++ b/ethstorage/storage_manager.go
@@ -5,7 +5,6 @@ package ethstorage
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"math/big"
@@ -13,7 +12,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -31,8 +29,6 @@ type Il1Source interface {
 	GetKvMetas(kvIndices []uint64, blockNumber int64) ([][32]byte, error)
 
 	GetStorageLastBlobIdx(blockNumber int64) (uint64, error)
-
-	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 }
 
 // StorageManager is a higher-level abstract of ShardManager which provides multi-thread safety to storage file read/write

--- a/ethstorage/storage_manager.go
+++ b/ethstorage/storage_manager.go
@@ -469,14 +469,12 @@ func (s *StorageManager) getKvMetas(kvIndices []uint64) ([][32]byte, error) {
 		meta, ok := s.blobMetas[i]
 		if ok {
 			metas = append(metas, meta)
+		} else if i >= s.lastKvIdx {
+			meta := [32]byte{}
+			new(big.Int).SetInt64(int64(i)).FillBytes(meta[0:5])
+			metas = append(metas, meta)
 		} else {
-			if i >= s.lastKvIdx {
-				meta := [32]byte{}
-				new(big.Int).SetInt64(int64(i)).FillBytes(meta[0:5])
-				metas = append(metas, meta)
-			} else {
-				return nil, errors.New("meta not found in blobMetas")
-			}
+			return nil, errors.New("meta not found in blobMetas")
 		}
 	}
 	return metas, nil

--- a/ethstorage/storage_manager_test.go
+++ b/ethstorage/storage_manager_test.go
@@ -57,11 +57,7 @@ func setup(t *testing.T) {
 
 func TestStorageManager_LastKvIndex(t *testing.T) {
 	setup(t)
-	idx, err := storageManager.LastKvIndex()
-	if err != nil {
-		t.Fatal("failed to get lastKvIndex", err)
-	}
-
+	idx := storageManager.LastKvIndex()
 	t.Log("lastKvIndex", idx)
 }
 


### PR DESCRIPTION
Every time es-node sends a BLOB p2p sync request or a local empty blob-filling, it will send a getKvMetas/getLastKvIdx RPC call. When the RPC latency is high, it will increase a lot of syncing time, and people can check https://github.com/ethstorage/es-node/issues/85 and https://github.com/ethstorage/es-node/issues/86 for more details.

Due to the slow update rate of on-chain blob hashes and lastKvIdx (every two Ethereum mainnet epochs), we can optimize the process by initially downloading them into the local cache before syncing. Subsequently, they can be updated by the downloader every two epochs. This approach allows the peer-to-peer (p2p) sync to directly utilize the local cache, rather than repeatedly making RPC requests, thereby enhancing overall syncing performance.

The implementation includes the following parts:
1. The p2p sync client checks if the syncing is done, and will start to download the metas if syncing is not done.
2. The download process is multi-threading (32 threads), and it takes around 5 mins for 8,000,000 blobs in our office.
3. The downloader will update the local meta cache and lastKvIdx every 2 epochs
4. The p2p sync client only uses the local meta/lastKvIndex cache when it commits blobs into the storage file.