### PR TITLE
Task summary output to log

### DIFF
--- a/ethstorage/miner/worker.go
+++ b/ethstorage/miner/worker.go
@@ -372,7 +372,7 @@ func (w *worker) mineTask(t *taskItem) (bool, error) {
 			}
 			w.lg.Debug("The nonces are exhausted in this slot, waiting for the next block",
 				"samplingTime", fmt.Sprintf("%.1fs", time.Since(startTime).Seconds()),
-				"shard", t.shardIdx, "thread", t.thread, "block", t.blockNumber, "nonce", nonce)
+				"shard", t.shardIdx, "thread", t.thread, "block", t.blockNumber, "nonceEnd", nonce)
 			break
 		}
 		hash0 := initHash(t.miner, t.blockHash, nonce)

--- a/ethstorage/miner/worker.go
+++ b/ethstorage/miner/worker.go
@@ -222,6 +222,7 @@ func (w *worker) assignTasks(task task, block eth.L1BlockRef, reqDiff *big.Int) 
 			w.lg.Debug("Mining task queued", "shard", ti.shardIdx, "thread", ti.thread, "block", ti.blockNumber, "blockTime", block.Time, "now", uint64(time.Now().Unix()))
 		}
 	}
+	w.lg.Info("Mining tasks assigned", "shard", task.shardIdx, "threads", w.config.ThreadsPerShard, "block", block.Number, "nonces", w.config.NonceLimit)
 }
 
 func (w *worker) updateDifficulty(shardIdx, blockTime uint64) (*big.Int, error) {
@@ -352,13 +353,16 @@ func (w *worker) checkTxStatus(txHash common.Hash, miner common.Address) {
 func (w *worker) mineTask(t *taskItem) (bool, error) {
 	startTime := time.Now()
 	nonce := t.nonceStart
-	if t.thread == 0 {
-		w.lg.Info("Mining tasks started", "shard", t.shardIdx, "threads", w.config.ThreadsPerShard, "block", t.blockNumber, "nonces", fmt.Sprintf("%d~%d", 0, w.config.NonceLimit))
-	}
 	w.lg.Debug("Mining task started", "shard", t.shardIdx, "thread", t.thread, "block", t.blockNumber, "nonces", fmt.Sprintf("%d~%d", t.nonceStart, t.nonceEnd))
 	for w.isRunning() {
 		if time.Since(startTime).Seconds() > mineTimeOut {
-			w.lg.Warn("Mining task timed out", "shard", t.shardIdx, "thread", t.thread, "block", t.blockNumber, "noncesTried", nonce-t.nonceStart)
+			if t.thread == 0 {
+				nonceTriedTotal := (nonce - t.nonceStart) * w.config.ThreadsPerShard
+				w.lg.Warn("Mining tasks timed out", "shard", t.shardIdx, "block", t.blockNumber,
+					"noncesTried", fmt.Sprintf("%d(%.1f%%)", nonceTriedTotal, float64(nonceTriedTotal)/float64(w.config.NonceLimit)),
+				)
+			}
+			w.lg.Debug("Mining task timed out", "shard", t.shardIdx, "thread", t.thread, "block", t.blockNumber, "noncesTried", nonce-t.nonceStart)
 			break
 		}
 		if nonce >= t.nonceEnd {

--- a/ethstorage/miner/worker.go
+++ b/ethstorage/miner/worker.go
@@ -359,7 +359,7 @@ func (w *worker) mineTask(t *taskItem) (bool, error) {
 			if t.thread == 0 {
 				nonceTriedTotal := (nonce - t.nonceStart) * w.config.ThreadsPerShard
 				w.lg.Warn("Mining tasks timed out", "shard", t.shardIdx, "block", t.blockNumber,
-					"noncesTried", fmt.Sprintf("%d(%.1f%%)", nonceTriedTotal, float64(nonceTriedTotal)/float64(w.config.NonceLimit)),
+					"noncesTried", fmt.Sprintf("%d(%.1f%%)", nonceTriedTotal, float64(nonceTriedTotal*100)/float64(w.config.NonceLimit)),
 				)
 			}
 			w.lg.Debug("Mining task timed out", "shard", t.shardIdx, "thread", t.thread, "block", t.blockNumber, "noncesTried", nonce-t.nonceStart)


### PR DESCRIPTION
To address https://github.com/ethstorage/es-node/issues/87, print summary in `assignTasks` and result in `mineTask` shard0. 
Now log be like:

```
INFO [11-24|03:09:34.125] Mining tasks assigned                    shard=0 threads=4 block=168,775 nonces=1,048,576
INFO [11-24|03:09:34.897] The nonces are exhausted in this slot, waiting for the next block samplingTime=0.8s shard=0 block=168,775
```
Or, 
```
INFO [11-24|04:40:24.534] Mining tasks assigned                    shard=0 threads=16 block=168,930 nonces=1,048,576
WARN [11-24|04:40:36.535] Mining tasks timed out                   shard=0 block=168,930 noncesTried=574064(54.7%)
```
