### PR TITLE
run.sh is runnable and accepts extra args

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -40,7 +40,8 @@ storage_file_0="$data_dir/shard-0.dat"
 common_flags=" --datadir $data_dir \
   --l1.rpc http://65.108.236.27:8545 \
   --storage.l1contract 0x9f9F5Fd89ad648f2C000C954d8d9C87743243eC5 \
-  --storage.miner $ES_NODE_STORAGE_MINER"
+  --storage.miner $ES_NODE_STORAGE_MINER \
+  $@"
 
 # init shard 0
 es_node_init="init --shard_index 0"


### PR DESCRIPTION
This allows us to run "./run.sh --p2p.ip.advertise=xxxx" with extra argument.