### PR TITLE
Build docker image, etc.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-# This workflow will publish an es-node release with a pre-build executable
+# This workflow will publish an es-node release with a pre-build executable and docker image
 
 name: Publish
 run-name: ${{ github.actor }} is publishing a release 🚀
@@ -6,9 +6,13 @@ on:
   push:
     tags: 
       - 'v*'
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      BUILD_DIR: es-node.${{ github.ref_name }}
+      BIN_DIR: es-node.${{ github.ref_name }}/build/bin
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -18,25 +22,79 @@ jobs:
         with:
           go-version: '1.20'
 
+      - name: Create package
+        run: |
+          mkdir -p ${{ env.BIN_DIR }}/snarkbuild
+          cp -r ethstorage/prover/snarkjs ${{ env.BIN_DIR }}
+          cp run.sh ${{ env.BUILD_DIR }}
+
       - name: Build
         run: |
-          make TARGETOS=linux TARGETARCH=amd64
-          mv cmd/es-node/es-node es-node.${{github.ref_name}}.linux-amd64
-          make TARGETOS=darwin TARGETARCH=amd64
-          mv cmd/es-node/es-node es-node.${{github.ref_name}}.darwin-amd64
-          make TARGETOS=darwin TARGETARCH=arm64
-          mv cmd/es-node/es-node es-node.${{github.ref_name}}.darwin-arm64
-          make TARGETOS=windows TARGETARCH=amd64
-          mv cmd/es-node/es-node es-node.${{github.ref_name}}.windows-amd64
+          make build TARGETOS=linux TARGETARCH=amd64
+          mv build/bin/es-node ${{ env.BIN_DIR }}/
+          tar -czvf es-node.${{ github.ref_name }}.linux-amd64.tar.gz ${{ env.BUILD_DIR }}
+          make clean
+          make build TARGETOS=darwin TARGETARCH=amd64
+          mv build/bin/es-node ${{ env.BIN_DIR }}/
+          tar -czvf es-node.${{ github.ref_name }}.darwin-amd64.tar.gz ${{ env.BUILD_DIR }}
+          make clean
+          make build TARGETOS=darwin TARGETARCH=arm64
+          mv build/bin/es-node ${{ env.BIN_DIR }}/
+          tar -czvf es-node.${{ github.ref_name }}.darwin-arm64.tar.gz ${{ env.BUILD_DIR }}
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref }}
-          name: Release ${{github.ref_name}}
+          name: Release ${{ github.ref_name }}
           files: |
-            es-node.${{github.ref_name}}.linux-amd64
-            es-node.${{github.ref_name}}.darwin-amd64
-            es-node.${{github.ref_name}}.darwin-arm64
-            es-node.${{github.ref_name}}.windows-amd64
+            es-node.${{ github.ref_name }}.linux-amd64.tar.gz
+            es-node.${{ github.ref_name }}.darwin-amd64.tar.gz
+            es-node.${{ github.ref_name }}.darwin-arm64.tar.gz
           generate_release_notes: true
+
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      # 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. 
+      # Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. 
+      # The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. 
+      # If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. 
+      # For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ build/_vendor/pkg
 .settings
 
 # executable
+es-node*
+/es-node*
+/build
+/es-node
 /cmd/es-node/es-node*
 /cmd/es-node/esnode_discovery_db/
 /cmd/es-node/esnode_peerstore_db/
@@ -34,6 +38,7 @@ build/_vendor/pkg
 /cmd/es-utils/blob-utils
 *.dat
 
+cookie
 *.zkey
 
 # shell

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,23 @@
 # Build ES node in a stock Go builder container
 FROM golang:1.20-alpine as builder
 
-RUN apk add --no-cache gcc musl-dev linux-headers
+RUN apk add --no-cache gcc musl-dev linux-headers make
 
-# Get dependencies - will also be cached if we won't change go.mod/go.sum
-COPY go.mod /es-node/
-COPY go.sum /es-node/
-RUN cd /es-node && go mod download
-
+# build
 ADD . /es-node
-RUN cd /es-node/cmd/es-node && go build
-RUN cd /es-node/cmd/es-utils && go build
+WORKDIR /es-node
+RUN make
 
 # Pull ES node into a second stage deploy alpine container
 FROM node:16-alpine
+COPY --from=builder /es-node/build/ /es-node/build/
 
-# For file download
-RUN apk add --no-cache curl grep
+# For zk proof
 RUN npm install -g snarkjs@0.7.0
-COPY --from=builder /es-node/ /es-node/
+RUN apk add --no-cache curl grep
+
+# Entrypoint
+COPY --from=builder /es-node/run.sh /es-node/
 RUN chmod +x /es-node/run.sh
 WORKDIR /es-node
 

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,15 @@ LDFLAGSSTRING +=-X main.Meta=$(VERSION_META)
 LDFLAGSSTRING +=-X 'main.BuildTime=$(BUILDDATE)'
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
-es-node:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./cmd/es-node/es-node ./cmd/es-node/
+es-node: build
+	cp -r ethstorage/prover/snarkjs build/bin
+	mkdir -p build/bin/snarkbuild
+
+build:
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o build/bin/es-node ./cmd/es-node/
 
 clean:
-	rm ./cmd/es-node/es-node
+	rm -r build
 
 test:
 	go test -v ./...

--- a/ethstorage/miner/cli.go
+++ b/ethstorage/miner/cli.go
@@ -78,7 +78,7 @@ func (c CLIConfig) Check() error {
 	info, err := os.Stat(filepath.Join(c.ZKWorkingDir, "snarkjs"))
 	if err != nil {
 		if os.IsNotExist(err) || !info.IsDir() {
-			return fmt.Errorf("snarkjs folder not found in ZKWorkingDir: %v\n", err)
+			return fmt.Errorf("snarkjs folder not found in ZKWorkingDir: %v", err)
 		}
 	}
 	return nil
@@ -89,7 +89,7 @@ func (c CLIConfig) ToMinerConfig() (Config, error) {
 	if !filepath.IsAbs(zkWorkingDir) {
 		dir, err := filepath.Abs(zkWorkingDir)
 		if err != nil {
-			return Config{}, fmt.Errorf("check ZKWorkingDir error: %v\n", err)
+			return Config{}, fmt.Errorf("check ZKWorkingDir error: %v", err)
 		}
 		zkWorkingDir = dir
 	}

--- a/ethstorage/miner/config.go
+++ b/ethstorage/miner/config.go
@@ -5,6 +5,7 @@ package miner
 
 import (
 	"math/big"
+	"path/filepath"
 	"runtime"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -37,6 +38,6 @@ var DefaultConfig = Config{
 	GasPrice:         nil,
 	PriorityGasPrice: nil,
 	ZKeyFileName:     "blob_poseidon.zkey",
-	ZKWorkingDir:     "build/bin",
+	ZKWorkingDir:     filepath.Join("ethstorage", "prover"),
 	ThreadsPerShard:  uint64(2 * runtime.NumCPU()),
 }

--- a/ethstorage/miner/config.go
+++ b/ethstorage/miner/config.go
@@ -38,6 +38,6 @@ var DefaultConfig = Config{
 	GasPrice:         nil,
 	PriorityGasPrice: nil,
 	ZKeyFileName:     "blob_poseidon.zkey",
-	ZKWorkingDir:     filepath.Join("ethstorage", "prover"),
+	ZKWorkingDir:     filepath.Join("build", "bin"),
 	ThreadsPerShard:  uint64(2 * runtime.NumCPU()),
 }

--- a/ethstorage/miner/config.go
+++ b/ethstorage/miner/config.go
@@ -5,7 +5,6 @@ package miner
 
 import (
 	"math/big"
-	"path/filepath"
 	"runtime"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -38,6 +37,6 @@ var DefaultConfig = Config{
 	GasPrice:         nil,
 	PriorityGasPrice: nil,
 	ZKeyFileName:     "blob_poseidon.zkey",
-	ZKWorkingDir:     filepath.Join("ethstorage", "prover"),
+	ZKWorkingDir:     "build/bin",
 	ThreadsPerShard:  uint64(2 * runtime.NumCPU()),
 }

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -24,31 +24,33 @@ if [ ${#ES_NODE_SIGNER_PRIVATE_KEY} -ne 64 ]; then
 fi
 
 container_name="es"
-image_name="ghcr.io/ethstorage/es-node" 
+image_name="es-node" 
 
 # check if container is running
 if sudo docker ps --format "{{.Names}}" | grep -q "^$container_name$"; then
-    echo "Container $container_name already started"
+    echo "container $container_name already started"
 else
     # start container if exist
     if sudo docker ps -a --format "{{.Names}}" | grep -q "^$container_name$"; then
         sudo docker start $container_name
-        echo "Container $container_name started"
+        echo "container $container_name started"
     else
-      # run container in the background from pre-built image
-      if sudo docker run --name $container_name \
-          -v ./es-data:/es-node/es-data \
-          -e ES_NODE_STORAGE_MINER=$ES_NODE_STORAGE_MINER \
-          -e ES_NODE_SIGNER_PRIVATE_KEY=$ES_NODE_SIGNER_PRIVATE_KEY \
-          -p 9545:9545 \
-          -p 9222:9222 \
-          -p 30305:30305/udp \
-          -d \
-          --entrypoint /es-node/run.sh \
-          $image_name; then
-          echo "Container $container_name started"
-        else
-          echo "Error: failed to run container from image $image_name"
-      fi
+        # build an image if not exist
+        if ! sudo docker images --format "{{.Repository}}" | grep -q "^$image_name$"; then
+            sudo docker build -t $image_name .
+            echo "image $image_name built"
+        fi
+        # run container in the background
+       sudo docker run --name $container_name \
+            -v ./es-data:/es-node/es-data \
+            -e ES_NODE_STORAGE_MINER=$ES_NODE_STORAGE_MINER \
+            -e ES_NODE_SIGNER_PRIVATE_KEY=$ES_NODE_SIGNER_PRIVATE_KEY \
+            -p 9545:9545 \
+            -p 9222:9222 \
+            -p 30305:30305/udp \
+            -d \
+            --entrypoint /es-node/run.sh \
+            $image_name
+        echo "container $container_name started"
     fi
 fi

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -24,33 +24,31 @@ if [ ${#ES_NODE_SIGNER_PRIVATE_KEY} -ne 64 ]; then
 fi
 
 container_name="es"
-image_name="es-node" 
+image_name="ghcr.io/ethstorage/es-node" 
 
 # check if container is running
 if sudo docker ps --format "{{.Names}}" | grep -q "^$container_name$"; then
-    echo "container $container_name already started"
+    echo "Container $container_name already started"
 else
     # start container if exist
     if sudo docker ps -a --format "{{.Names}}" | grep -q "^$container_name$"; then
         sudo docker start $container_name
-        echo "container $container_name started"
+        echo "Container $container_name started"
     else
-        # build an image if not exist
-        if ! sudo docker images --format "{{.Repository}}" | grep -q "^$image_name$"; then
-            sudo docker build -t $image_name .
-            echo "image $image_name built"
-        fi
-        # run container in the background
-       sudo docker run --name $container_name \
-            -v ./es-data:/es-node/es-data \
-            -e ES_NODE_STORAGE_MINER=$ES_NODE_STORAGE_MINER \
-            -e ES_NODE_SIGNER_PRIVATE_KEY=$ES_NODE_SIGNER_PRIVATE_KEY \
-            -p 9545:9545 \
-            -p 9222:9222 \
-            -p 30305:30305/udp \
-            -d \
-            --entrypoint /es-node/run.sh \
-            $image_name
-        echo "container $container_name started"
+      # run container in the background from pre-built image
+      if sudo docker run --name $container_name \
+          -v ./es-data:/es-node/es-data \
+          -e ES_NODE_STORAGE_MINER=$ES_NODE_STORAGE_MINER \
+          -e ES_NODE_SIGNER_PRIVATE_KEY=$ES_NODE_SIGNER_PRIVATE_KEY \
+          -p 9545:9545 \
+          -p 9222:9222 \
+          -p 30305:30305/udp \
+          -d \
+          --entrypoint /es-node/run.sh \
+          $image_name; then
+          echo "Container $container_name started"
+        else
+          echo "Error: failed to run container from image $image_name"
+      fi
     fi
 fi

--- a/run-rpc.sh
+++ b/run-rpc.sh
@@ -3,7 +3,7 @@
 # usage:
 # ./run_rpc.sh
 
-executable="./cmd/es-node/es-node"
+executable="./es-node"
 data_dir="./es-data"
 storage_file_0="$data_dir/shard-0.dat"
 

--- a/run-rpc.sh
+++ b/run-rpc.sh
@@ -3,13 +3,13 @@
 # usage:
 # ./run_rpc.sh
 
-executable="./es-node"
+executable="./build/bin/es-node"
 data_dir="./es-data"
 storage_file_0="$data_dir/shard-0.dat"
 
 common_flags=" --datadir $data_dir \
-  --l1.rpc http://65.108.236.27:8545 \
-  --storage.l1contract 0x9f9F5Fd89ad648f2C000C954d8d9C87743243eC5"
+  --l1.rpc http://65.109.115.36:8545 \
+  --storage.l1contract 0xb4B46bdAA835F8E4b4d8e208B6559cD267851051 \
 
 # init shard 0
 es_node_init="init --shard_index 0"
@@ -18,8 +18,8 @@ es_node_init="init --shard_index 0"
 # TODO remove --network
 es_node_start=" --network devnet \
   --storage.files $storage_file_0 \
-  --l1.beacon http://65.108.236.27:5052 \
-  --l1.beacon-based-time 1698751812 \
+  --l1.beacon http://65.109.115.36:5052 \
+  --l1.beacon-based-time 1701262812 \
   --l1.beacon-based-slot 1 \
   --p2p.listen.udp 30305 \
  "

--- a/run.sh
+++ b/run.sh
@@ -29,7 +29,7 @@ if [ ! -e  ${zkey_file} ]; then
   echo "${zkey_file} not found, start downloading..."
   file_id="1ZLfhYeCXMnbk6wUiBADRAn1mZ8MI_zg-"
   html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${file_id}"`
-  curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${file_id}" -o ${zkey_file}
+  curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -o '(confirm=[a-zA-Z0-9\-_]+)'`&id=${file_id}" -o ${zkey_file}
 fi
 
 executable="./build/bin/es-node"

--- a/run.sh
+++ b/run.sh
@@ -29,7 +29,7 @@ if [ ! -e  ${zkey_file} ]; then
   echo "${zkey_file} not found, start downloading..."
   file_id="1ZLfhYeCXMnbk6wUiBADRAn1mZ8MI_zg-"
   html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${file_id}"`
-  curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -o '(confirm=[a-zA-Z0-9\-_]+)'`&id=${file_id}" -o ${zkey_file}
+  curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${file_id}" -o ${zkey_file}
 fi
 
 executable="./build/bin/es-node"

--- a/run.sh
+++ b/run.sh
@@ -24,16 +24,15 @@ if [ ${#ES_NODE_SIGNER_PRIVATE_KEY} -ne 64 ]; then
 fi
 
 # download blob_poseidon.zkey if not yet
-zkey_file="./ethstorage/prover/snarkjs/blob_poseidon.zkey"
+zkey_file="./build/bin/snarkjs/blob_poseidon.zkey"
 if [ ! -e  ${zkey_file} ]; then
-  echo "${zkey_file} not found. Start downloading..."
-  file_id="1ZLfhYeCXMnbk6wUiBADRAn1mZ8MI_zg-"
-  html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${file_id}"`
-  curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${file_id}" -o ${zkey_file}
-  echo "downloaded ${zkey_file}"
+echo "${zkey_file} not found, start downloading..."
+file_id="1ZLfhYeCXMnbk6wUiBADRAn1mZ8MI_zg-"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${file_id}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${file_id}" -o ${zkey_file}
 fi
 
-executable="./cmd/es-node/es-node"
+executable="./build/bin/es-node"
 data_dir="./es-data"
 storage_file_0="$data_dir/shard-0.dat"
 
@@ -62,14 +61,14 @@ es_node_start=" --network devnet \
   --download.thread 32 \
   --p2p.max.request.size 4194304 \
   --p2p.max.concurrency 32 \
-  --p2p.bootnodes enr:-Li4QPFCNc7mLPqxoVrk1eKB0qa5hb8H75IBwhvdSGGdamx1egKibkKO1v1rtLt7r3pJvoVxv95ITlpSphYCAsunU6qGAYwkwuOpimV0aHN0b3JhZ2XbAYDY15S0tGvaqDX45LTY4gi2VZzSZ4UQUcGAgmlkgnY0gmlwhEFtcySJc2VjcDI1NmsxoQM9rkUZ7qWoJQT2UVrPzDRzmLqDrxCSR4zC4db-lgz1bYN0Y3CCJAaDdWRwgnZh \
-"
+--p2p.bootnodes enr:-Li4QPFCNc7mLPqxoVrk1eKB0qa5hb8H75IBwhvdSGGdamx1egKibkKO1v1rtLt7r3pJvoVxv95ITlpSphYCAsunU6qGAYwkwuOpimV0aHN0b3JhZ2XbAYDY15S0tGvaqDX45LTY4gi2VZzSZ4UQUcGAgmlkgnY0gmlwhEFtcySJc2VjcDI1NmsxoQM9rkUZ7qWoJQT2UVrPzDRzmLqDrxCSR4zC4db-lgz1bYN0Y3CCJAaDdWRwgnZh \
+  "
 # create data file for shard 0 if not yet
 if [ ! -e $storage_file_0 ]; then
   if $executable $es_node_init $common_flags ; then
-    echo "initialized ${storage_file_0} successfully"
+    echo "Initialized ${storage_file_0} successfully"
   else
-    echo "failed to initialize ${storage_file_0}"
+    echo "Error: failed to initialize ${storage_file_0}"
     exit 1
   fi
 fi

--- a/run.sh
+++ b/run.sh
@@ -29,7 +29,7 @@ if [ ! -e  ${zkey_file} ]; then
   echo "${zkey_file} not found, start downloading..."
   file_id="1ZLfhYeCXMnbk6wUiBADRAn1mZ8MI_zg-"
   html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${file_id}"`
-  curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${file_id}" -o ${zkey_file}
+  curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Eo 'confirm=[a-zA-Z0-9\-_]+'`&id=${file_id}" -o ${zkey_file}
 fi
 
 executable="./build/bin/es-node"

--- a/run.sh
+++ b/run.sh
@@ -26,10 +26,10 @@ fi
 # download blob_poseidon.zkey if not yet
 zkey_file="./build/bin/snarkjs/blob_poseidon.zkey"
 if [ ! -e  ${zkey_file} ]; then
-echo "${zkey_file} not found, start downloading..."
-file_id="1ZLfhYeCXMnbk6wUiBADRAn1mZ8MI_zg-"
-html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${file_id}"`
-curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${file_id}" -o ${zkey_file}
+  echo "${zkey_file} not found, start downloading..."
+  file_id="1ZLfhYeCXMnbk6wUiBADRAn1mZ8MI_zg-"
+  html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${file_id}"`
+  curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${file_id}" -o ${zkey_file}
 fi
 
 executable="./build/bin/es-node"
@@ -61,8 +61,8 @@ es_node_start=" --network devnet \
   --download.thread 32 \
   --p2p.max.request.size 4194304 \
   --p2p.max.concurrency 32 \
---p2p.bootnodes enr:-Li4QPFCNc7mLPqxoVrk1eKB0qa5hb8H75IBwhvdSGGdamx1egKibkKO1v1rtLt7r3pJvoVxv95ITlpSphYCAsunU6qGAYwkwuOpimV0aHN0b3JhZ2XbAYDY15S0tGvaqDX45LTY4gi2VZzSZ4UQUcGAgmlkgnY0gmlwhEFtcySJc2VjcDI1NmsxoQM9rkUZ7qWoJQT2UVrPzDRzmLqDrxCSR4zC4db-lgz1bYN0Y3CCJAaDdWRwgnZh \
-  "
+  --p2p.bootnodes enr:-Li4QPFCNc7mLPqxoVrk1eKB0qa5hb8H75IBwhvdSGGdamx1egKibkKO1v1rtLt7r3pJvoVxv95ITlpSphYCAsunU6qGAYwkwuOpimV0aHN0b3JhZ2XbAYDY15S0tGvaqDX45LTY4gi2VZzSZ4UQUcGAgmlkgnY0gmlwhEFtcySJc2VjcDI1NmsxoQM9rkUZ7qWoJQT2UVrPzDRzmLqDrxCSR4zC4db-lgz1bYN0Y3CCJAaDdWRwgnZh \
+"
 # create data file for shard 0 if not yet
 if [ ! -e $storage_file_0 ]; then
   if $executable $es_node_init $common_flags ; then


### PR DESCRIPTION
Replaced https://github.com/ethstorage/es-node/pull/115

1. release zip with scripts and pre-built binaries
2. build a Docker image and push it to  GitHub Container Registry (ghcr.io) on each release
    - can be managed in https://github.com/orgs/ethstorage/packages
3. move the built binary (es-node) and snark folders(snarkjs, snarkbuild) to build/bin so that does not depend on src structures.

Note that the corresponding documentation will be changed in https://github.com/ethstorage/es-node/pull/92