### PR TITLE
Estimate mining profit

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The full list of options that you can use to configure an es-node are as follows
 |`--miner.threads-per-shard`|Number of threads per shard|`runtime.NumCPU() x 2`||
 |`--miner.zk-working-dir`|Path to the snarkjs folder|`build/bin`||
 |`--miner.zkey`|zkey file name which should be put in the snarkjs folder|`blob_poseidon.zkey`||
+|`--miner.min-profit`|Minimum profit for mining transactions|`0`||
 |`--network`|Predefined L1 network selection. Available networks: devnet|||
 |`--p2p.advertise.ip`|The IP address to advertise in Discv5, put into the ENR of the node. This may also be a hostname / domain name to resolve to an IP.|||
 |`--p2p.advertise.tcp`|The TCP port to advertise in Discv5, put into the ENR of the node. Set to p2p.listen.tcp value if 0.|`0`||

--- a/cmd/es-node/config.go
+++ b/cmd/es-node/config.go
@@ -156,13 +156,10 @@ func NewMinerConfig(ctx *cli.Context, client *ethclient.Client, l1Contract commo
 		return nil, err
 	}
 	minerConfig.DiffAdjDivisor = diffAdjDivisor
-	dcff, err := readBigIntFromContract(cctx, client, l1Contract, "dcfFactor")
+	dcf, err := readBigIntFromContract(cctx, client, l1Contract, "dcfFactor")
 	if err != nil {
 		return nil, err
 	}
-	base := new(big.Int).Exp(big.NewInt(2), big.NewInt(128), nil)
-	dcf := new(big.Rat).SetFrac(dcff, base)
-	log.Info("Read big int from contract", "dcfInSecond", dcf.FloatString(10))
 	minerConfig.DcfFactor = dcf
 
 	startTime, err := readUintFromContract(cctx, client, l1Contract, "startTime")

--- a/cmd/es-node/config.go
+++ b/cmd/es-node/config.go
@@ -156,7 +156,35 @@ func NewMinerConfig(ctx *cli.Context, client *ethclient.Client, l1Contract commo
 		return nil, err
 	}
 	minerConfig.DiffAdjDivisor = diffAdjDivisor
+	dcff, err := readBigIntFromContract(cctx, client, l1Contract, "dcfFactor")
+	if err != nil {
+		return nil, err
+	}
+	base := new(big.Int).Exp(big.NewInt(2), big.NewInt(128), nil)
+	dcf := new(big.Rat).SetFrac(dcff, base)
+	fmt.Println("dcf in sec", dcf.FloatString(10))
+	minerConfig.DcfFactor = dcf
 
+	startTime, err := readUintFromContract(cctx, client, l1Contract, "startTime")
+	if err != nil {
+		return nil, err
+	}
+	minerConfig.StartTime = startTime
+	shardEntryBits, err := readUintFromContract(cctx, client, l1Contract, "shardEntryBits")
+	if err != nil {
+		return nil, err
+	}
+	minerConfig.ShardEntry = 1 << shardEntryBits
+	storageCost, err := readBigIntFromContract(cctx, client, l1Contract, "storageCost")
+	if err != nil {
+		return nil, err
+	}
+	minerConfig.StorageCost = storageCost
+	prepaidAmount, err := readBigIntFromContract(cctx, client, l1Contract, "prepaidAmount")
+	if err != nil {
+		return nil, err
+	}
+	minerConfig.PrepaidAmount = prepaidAmount
 	signerFnFactory, signerAddr, err := NewSignerConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get signer: %w", err)

--- a/cmd/es-node/config.go
+++ b/cmd/es-node/config.go
@@ -175,6 +175,11 @@ func NewMinerConfig(ctx *cli.Context, client *ethclient.Client, l1Contract commo
 		return nil, err
 	}
 	minerConfig.ShardEntry = 1 << shardEntryBits
+	treasuryShare, err := readUintFromContract(cctx, client, l1Contract, "treasuryShare")
+	if err != nil {
+		return nil, err
+	}
+	minerConfig.TreasuryShare = treasuryShare
 	storageCost, err := readBigIntFromContract(cctx, client, l1Contract, "storageCost")
 	if err != nil {
 		return nil, err

--- a/cmd/es-node/config.go
+++ b/cmd/es-node/config.go
@@ -162,7 +162,7 @@ func NewMinerConfig(ctx *cli.Context, client *ethclient.Client, l1Contract commo
 	}
 	base := new(big.Int).Exp(big.NewInt(2), big.NewInt(128), nil)
 	dcf := new(big.Rat).SetFrac(dcff, base)
-	fmt.Println("dcf in sec", dcf.FloatString(10))
+	log.Info("Read big int from contract", "dcfInSecond", dcf.FloatString(10))
 	minerConfig.DcfFactor = dcf
 
 	startTime, err := readUintFromContract(cctx, client, l1Contract, "startTime")

--- a/ethstorage/eth/polling_client.go
+++ b/ethstorage/eth/polling_client.go
@@ -3,6 +3,7 @@ package eth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"regexp"
 	"sync"
@@ -269,4 +270,17 @@ func (w *PollingClient) GetKvMetas(kvIndices []uint64, blockNumber int64) ([][32
 	}
 
 	return res[0].([][32]byte), nil
+}
+
+func (w *PollingClient) ReadContractField(fieldName string) ([]byte, error) {
+	h := crypto.Keccak256Hash([]byte(fieldName + "()"))
+	msg := ethereum.CallMsg{
+		To:   &w.esContract,
+		Data: h[0:4],
+	}
+	bs, err := w.Client.CallContract(context.Background(), msg, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get %s from contract: %v", fieldName, err)
+	}
+	return bs, nil
 }

--- a/ethstorage/miner/cli.go
+++ b/ethstorage/miner/cli.go
@@ -18,9 +18,10 @@ const (
 	EnabledFlagName          = "miner.enabled"
 	GasPriceFlagName         = "miner.gas-price"
 	PriorityGasPriceFlagName = "miner.priority-gas-price"
-	ZKeyFileName             = "miner.zkey"
-	ZKWorkingDir             = "miner.zk-working-dir"
-	ThreadsPerShard          = "miner.threads-per-shard"
+	ZKeyFileNameFlagName     = "miner.zkey"
+	ZKWorkingDirFlagName     = "miner.zk-working-dir"
+	ThreadsPerShardFlagName  = "miner.threads-per-shard"
+	MinimumProfitFlagName    = "miner.min-profit"
 )
 
 func CLIFlags(envPrefix string) []cli.Flag {
@@ -43,20 +44,26 @@ func CLIFlags(envPrefix string) []cli.Flag {
 			Value:  DefaultConfig.PriorityGasPrice,
 			EnvVar: rollup.PrefixEnvVar(envPrefix, "PRIORITY_GAS_PRICE"),
 		},
+		&types.BigFlag{
+			Name:   MinimumProfitFlagName,
+			Usage:  "Minimum profit for mining transactions",
+			Value:  DefaultConfig.MinimumProfit,
+			EnvVar: rollup.PrefixEnvVar(envPrefix, "MIN_PROFIT"),
+		},
 		cli.StringFlag{
-			Name:   ZKeyFileName,
+			Name:   ZKeyFileNameFlagName,
 			Usage:  "zkey file name which should be put in the snarkjs folder",
 			Value:  DefaultConfig.ZKeyFileName,
 			EnvVar: rollup.PrefixEnvVar(envPrefix, "ZKEY_FILE"),
 		},
 		cli.StringFlag{
-			Name:   ZKWorkingDir,
+			Name:   ZKWorkingDirFlagName,
 			Usage:  "Path to the snarkjs folder",
 			Value:  DefaultConfig.ZKWorkingDir,
 			EnvVar: rollup.PrefixEnvVar(envPrefix, "ZK_WORKING_DIR"),
 		},
 		cli.Uint64Flag{
-			Name:   ThreadsPerShard,
+			Name:   ThreadsPerShardFlagName,
 			Usage:  "Number of threads per shard",
 			Value:  DefaultConfig.ThreadsPerShard,
 			EnvVar: rollup.PrefixEnvVar(envPrefix, "THREADS_PER_SHARD"),
@@ -69,6 +76,7 @@ type CLIConfig struct {
 	Enabled          bool
 	GasPrice         *big.Int
 	PriorityGasPrice *big.Int
+	MinimumProfit    *big.Int
 	ZKeyFileName     string
 	ZKWorkingDir     string
 	ThreadsPerShard  uint64
@@ -97,6 +105,7 @@ func (c CLIConfig) ToMinerConfig() (Config, error) {
 	cfg.ZKWorkingDir = zkWorkingDir
 	cfg.GasPrice = c.GasPrice
 	cfg.PriorityGasPrice = c.PriorityGasPrice
+	cfg.MinimumProfit = c.MinimumProfit
 	cfg.ZKeyFileName = c.ZKeyFileName
 	cfg.ThreadsPerShard = c.ThreadsPerShard
 	return cfg, nil
@@ -107,9 +116,10 @@ func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 		Enabled:          ctx.GlobalBool(EnabledFlagName),
 		GasPrice:         types.GlobalBig(ctx, GasPriceFlagName),
 		PriorityGasPrice: types.GlobalBig(ctx, PriorityGasPriceFlagName),
-		ZKeyFileName:     ctx.GlobalString(ZKeyFileName),
-		ZKWorkingDir:     ctx.GlobalString(ZKWorkingDir),
-		ThreadsPerShard:  ctx.GlobalUint64(ThreadsPerShard),
+		MinimumProfit:    types.GlobalBig(ctx, MinimumProfitFlagName),
+		ZKeyFileName:     ctx.GlobalString(ZKeyFileNameFlagName),
+		ZKWorkingDir:     ctx.GlobalString(ZKWorkingDirFlagName),
+		ThreadsPerShard:  ctx.GlobalUint64(ThreadsPerShardFlagName),
 	}
 	return cfg
 }

--- a/ethstorage/miner/config.go
+++ b/ethstorage/miner/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	NonceLimit     uint64
 	StartTime      uint64
 	ShardEntry     uint64
+	TreasuryShare  uint64
 	MinimumDiff    *big.Int
 	Cutoff         *big.Int
 	DiffAdjDivisor *big.Int

--- a/ethstorage/miner/config.go
+++ b/ethstorage/miner/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	DiffAdjDivisor *big.Int
 	StorageCost    *big.Int
 	PrepaidAmount  *big.Int
-	DcfFactor      *big.Rat
+	DcfFactor      *big.Int
 
 	// cli
 	GasPrice         *big.Int

--- a/ethstorage/miner/config.go
+++ b/ethstorage/miner/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	ThreadsPerShard  uint64
 	SignerFnFactory  signer.SignerFactory
 	SignerAddr       common.Address
+	MinimumProfit    *big.Int
 }
 
 var DefaultConfig = Config{
@@ -40,4 +41,5 @@ var DefaultConfig = Config{
 	ZKeyFileName:     "blob_poseidon.zkey",
 	ZKWorkingDir:     filepath.Join("build", "bin"),
 	ThreadsPerShard:  uint64(2 * runtime.NumCPU()),
+	MinimumProfit:    common.Big0,
 }

--- a/ethstorage/miner/config.go
+++ b/ethstorage/miner/config.go
@@ -13,12 +13,19 @@ import (
 )
 
 type Config struct {
+	// contract
 	RandomChecks   uint64
 	NonceLimit     uint64
+	StartTime      uint64
+	ShardEntry     uint64
 	MinimumDiff    *big.Int
 	Cutoff         *big.Int
 	DiffAdjDivisor *big.Int
+	StorageCost    *big.Int
+	PrepaidAmount  *big.Int
+	DcfFactor      *big.Rat
 
+	// cli
 	GasPrice         *big.Int
 	PriorityGasPrice *big.Int
 	ZKeyFileName     string

--- a/ethstorage/miner/l1_mining_api.go
+++ b/ethstorage/miner/l1_mining_api.go
@@ -144,11 +144,11 @@ func (m *l1MiningAPI) SubmitMinedResult(ctx context.Context, contract common.Add
 	profit := new(big.Int).Sub(reward, cost)
 	m.lg.Info("Estimated reward and cost (in ether)", "reward", weiToEther(reward), "cost", weiToEther(cost), "profit", weiToEther(profit))
 	if profit.Cmp(cfg.MinimumProfit) == -1 {
-		m.lg.Warn("Will quit the tx: the profit will not meet expectation",
+		m.lg.Warn("Will drop the tx: the profit will not meet expectation",
 			"profitEstimated", weiToEther(profit),
 			"minimumProfit", weiToEther(cfg.MinimumProfit),
 		)
-		return common.Hash{}, fmt.Errorf("quit: not enough profit")
+		return common.Hash{}, fmt.Errorf("dropped: not enough profit")
 	}
 
 	chainID, err := m.NetworkID(ctx)

--- a/ethstorage/miner/l1_mining_api.go
+++ b/ethstorage/miner/l1_mining_api.go
@@ -189,6 +189,7 @@ func (m *l1MiningAPI) SubmitMinedResult(ctx context.Context, contract common.Add
 	return signedTx.Hash(), nil
 }
 
+// TODO: implement `miningReward()` in the contract to replace this impl
 func (m *l1MiningAPI) estimateReward(ctx context.Context, cfg Config, contract common.Address, shard uint64, block *big.Int) (*big.Int, error) {
 
 	lastKv, err := m.PollingClient.GetStorageLastBlobIdx(rpc.LatestBlockNumber.Int64())

--- a/ethstorage/miner/l1_mining_api.go
+++ b/ethstorage/miner/l1_mining_api.go
@@ -143,9 +143,12 @@ func (m *l1MiningAPI) SubmitMinedResult(ctx context.Context, contract common.Add
 		return common.Hash{}, err
 	}
 	profit := new(big.Int).Sub(reward, cost)
-	m.lg.Info("Estimated reward done", "reward", reward, "profit", profit)
+	m.lg.Info("Estimated reward done (in ether)", "reward", weiToEther(reward), "cost", weiToEther(cost), "profit", weiToEther(profit))
 	if profit.Cmp(cfg.MinimumProfit) == -1 {
-		m.lg.Warn("Will quit the tx: the profit will not meet expectation", "profitEstimated", profit, "minimumProfit", cfg.MinimumProfit)
+		m.lg.Warn("Will quit the tx: the profit will not meet expectation",
+			"profitEstimated", weiToEther(profit),
+			"minimumProfit", weiToEther(cfg.MinimumProfit),
+		)
 		return common.Hash{}, fmt.Errorf("quit: not enough profit")
 	}
 

--- a/ethstorage/miner/worker.go
+++ b/ethstorage/miner/worker.go
@@ -358,7 +358,7 @@ func (w *worker) checkTxStatus(txHash common.Hash, miner common.Address) {
 				reward = new(big.Int).SetBytes(rLog.Data[64:])
 			}
 		}
-		log.Info("Mining transaction accounting (in ether)", "cost", weiToEther(cost), "reward", weiToEther(reward), "profit", weiToEther(new(big.Int).Sub(reward, cost)))
+		log.Info("Mining transaction accounting (in ether)", "reward", weiToEther(reward), "cost", weiToEther(cost), "profit", weiToEther(new(big.Int).Sub(reward, cost)))
 	} else if receipt.Status == 0 {
 		log.Warn("Mining transaction failed!      ×", "txHash", txHash)
 	}

--- a/ethstorage/miner/worker.go
+++ b/ethstorage/miner/worker.go
@@ -12,8 +12,9 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethstorage/go-ethstorage/ethstorage"
+	"github.com/ethereum/go-ethereum/params"
 	es "github.com/ethstorage/go-ethstorage/ethstorage"
 	"github.com/ethstorage/go-ethstorage/ethstorage/eth"
 )
@@ -26,6 +27,10 @@ const (
 	// always use new block hash to mine for each slot
 	mineTimeOut              = 12 // seconds
 	miningTransactionTimeout = 25 // seconds
+)
+
+var (
+	minedEventSig = crypto.Keccak256Hash([]byte("MinedBlock(uint256,uint256,uint256,uint256,address,uint256)"))
 )
 
 type task struct {
@@ -83,7 +88,7 @@ type worker struct {
 
 func newWorker(
 	config Config,
-	storageMgr *ethstorage.StorageManager,
+	storageMgr *es.StorageManager,
 	api L1API,
 	chainHeadCh chan eth.L1BlockRef,
 	prover MiningProver,
@@ -344,9 +349,30 @@ func (w *worker) checkTxStatus(txHash common.Hash, miner common.Address) {
 		log.Warn("Mining transaction not found!", "err", err, "txHash", txHash)
 	} else if receipt.Status == 1 {
 		log.Info("Mining transaction success!      √", "miner", miner)
+		log.Info("Mining transaction details", "txHash", txHash, "gasUsed", receipt.GasUsed, "effectiveGasPrice", receipt.EffectiveGasPrice)
+		cost := new(big.Int).Mul(new(big.Int).SetUint64(receipt.GasUsed), receipt.EffectiveGasPrice)
+		var reward *big.Int
+		for _, rLog := range receipt.Logs {
+			if rLog.Topics[0] == minedEventSig {
+				// the last param of total unindexed 3
+				reward = new(big.Int).SetBytes(rLog.Data[64:])
+			}
+		}
+		log.Info("Mining transaction accounting (in ether)", "cost", weiToEther(cost), "reward", weiToEther(reward), "profit", weiToEther(new(big.Int).Sub(reward, cost)))
 	} else if receipt.Status == 0 {
 		log.Warn("Mining transaction failed!      ×", "txHash", txHash)
 	}
+}
+
+// https://github.com/ethereum/go-ethereum/issues/21221#issuecomment-805852059
+func weiToEther(wei *big.Int) *big.Float {
+	f := new(big.Float)
+	f.SetPrec(236) //  IEEE 754 octuple-precision binary floating-point format: binary256
+	f.SetMode(big.ToNearestEven)
+	fWei := new(big.Float)
+	fWei.SetPrec(236) //  IEEE 754 octuple-precision binary floating-point format: binary256
+	fWei.SetMode(big.ToNearestEven)
+	return f.Quo(fWei.SetInt(wei), big.NewFloat(params.Ether))
 }
 
 // mineTask acturally executes a mining task

--- a/ethstorage/miner/worker.go
+++ b/ethstorage/miner/worker.go
@@ -356,9 +356,16 @@ func (w *worker) checkTxStatus(txHash common.Hash, miner common.Address) {
 			if rLog.Topics[0] == minedEventSig {
 				// the last param of total unindexed 3
 				reward = new(big.Int).SetBytes(rLog.Data[64:])
+				break
 			}
 		}
-		log.Info("Mining transaction accounting (in ether)", "reward", weiToEther(reward), "cost", weiToEther(cost), "profit", weiToEther(new(big.Int).Sub(reward, cost)))
+		if reward != nil {
+			log.Info("Mining transaction accounting (in ether)",
+				"reward", weiToEther(reward),
+				"cost", weiToEther(cost),
+				"profit", weiToEther(new(big.Int).Sub(reward, cost)),
+			)
+		}
 	} else if receipt.Status == 0 {
 		log.Warn("Mining transaction failed!      ×", "txHash", txHash)
 	}
@@ -369,6 +376,9 @@ func weiToEther(wei *big.Int) *big.Float {
 	f := new(big.Float)
 	f.SetPrec(236) //  IEEE 754 octuple-precision binary floating-point format: binary256
 	f.SetMode(big.ToNearestEven)
+	if wei == nil {
+		return f.SetInt64(0)
+	}
 	fWei := new(big.Float)
 	fWei.SetPrec(236) //  IEEE 754 octuple-precision binary floating-point format: binary256
 	fWei.SetMode(big.ToNearestEven)

--- a/run.sh
+++ b/run.sh
@@ -50,8 +50,6 @@ es_node_init="init --shard_index 0"
 # TODO remove --miner.priority-gas-price and --miner.gas-price when gas price query is available
 es_node_start=" --network devnet \
   --miner.enabled \
-  --miner.priority-gas-price 5000000000 \
-  --miner.gas-price 30000000000 \
   --storage.files $storage_file_0 \
   --signer.private-key $ES_NODE_SIGNER_PRIVATE_KEY \
   --l1.beacon http://65.109.115.36:5052 \


### PR DESCRIPTION
Estimate tx cost and mining reward and compare the profit to the min-profit flag before submitting mining txes.
- implement miner's reward computation based on the logic of the smart contract
- read the actual cost and reward from tx receipt for users to check.
- remove gas price related settings from run.sh so that a market price can be used.