### PR TITLE
issue157: CTRL+C should stop es-node immediately during meta download phase

### DIFF
--- a/ethstorage/p2p/protocol/sync_test.go
+++ b/ethstorage/p2p/protocol/sync_test.go
@@ -561,7 +561,7 @@ func TestSync_RequestL2Range(t *testing.T) {
 	localHost, syncCl := createLocalHostAndSyncClient(t, testLog, rollupCfg, db, sm, m, mux)
 	syncCl.loadSyncStatus()
 	sm.Reset(0)
-	err = sm.DownloadAllMetas(16)
+	err = sm.DownloadAllMetas(context.Background(), 16)
 	if err != nil {
 		t.Fatal("Download blob metadata failed", "error", err)
 		return
@@ -634,7 +634,7 @@ func TestSync_RequestL2List(t *testing.T) {
 	localHost, syncCl := createLocalHostAndSyncClient(t, testLog, rollupCfg, db, sm, m, mux)
 	syncCl.loadSyncStatus()
 	sm.Reset(0)
-	err = sm.DownloadAllMetas(16)
+	err = sm.DownloadAllMetas(context.Background(), 16)
 	if err != nil {
 		t.Fatal("Download blob metadata failed", "error", err)
 		return

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -134,7 +134,7 @@ type StorageManager interface {
 
 	DecodeKV(kvIdx uint64, b []byte, hash common.Hash, providerAddr common.Address, encodeType uint64) ([]byte, bool, error)
 
-	DownloadAllMetas(batchSize uint64) error
+	DownloadAllMetas(ctx context.Context, batchSize uint64) error
 }
 
 type SyncClient struct {
@@ -573,7 +573,7 @@ func (s *SyncClient) mainLoop() {
 
 	s.cleanTasks()
 	if !s.syncDone {
-		err := s.storageManager.DownloadAllMetas(s.syncerParams.MetaDownloadBatchSize)
+		err := s.storageManager.DownloadAllMetas(s.resCtx, s.syncerParams.MetaDownloadBatchSize)
 		if err != nil {
 			log.Error("Download blob metadata failed", "error", err)
 			return

--- a/ethstorage/storage_manager_test.go
+++ b/ethstorage/storage_manager_test.go
@@ -4,6 +4,7 @@
 package ethstorage
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -235,7 +236,7 @@ func TestStorageManager_CommitBlobs(t *testing.T) {
 
 func TestStorageManager_DownloadAllMeta(t *testing.T) {
 	setup(t)
-	err := storageManager.DownloadAllMetas(4)
+	err := storageManager.DownloadAllMetas(context.Background(), 4)
 	if err != nil {
 		t.Fatal("failed to Downloand Finished", err)
 	}


### PR DESCRIPTION
related issue: https://github.com/ethstorage/es-node/issues/157

Expected behaviour
CTRL+C should stop es-node immediately during the meta-download phase

How to test:
Start a node and wait until meta-download starts. then CTRL+C to stop the node and the es-node immediately during the meta-download phase.

