### PR TITLE
Use randao to replace block hash

### DIFF
--- a/ethstorage/eth/heads.go
+++ b/ethstorage/eth/heads.go
@@ -38,6 +38,7 @@ func WatchHeadChanges(ctx context.Context, src NewHeadSource, fn HeadSignalFn) (
 					Number:     header.Number.Uint64(),
 					ParentHash: header.ParentHash,
 					Time:       header.Time,
+					MixDigest:  header.MixDigest,
 				})
 			case err := <-sub.Err():
 				return err

--- a/ethstorage/eth/id.go
+++ b/ethstorage/eth/id.go
@@ -45,6 +45,7 @@ type L1BlockRef struct {
 	Number     uint64      `json:"number"`
 	ParentHash common.Hash `json:"parentHash"`
 	Time       uint64      `json:"timestamp"`
+	MixDigest  common.Hash `json:"mixDigest"`
 }
 
 func (id L1BlockRef) String() string {

--- a/ethstorage/miner/algorithm.go
+++ b/ethstorage/miner/algorithm.go
@@ -32,10 +32,10 @@ func hashimoto(kvEntriesBits, kvSizeBits, sampleSizeBits, shardIdx, randomChecks
 	return hash0, sampleIdxs, nil
 }
 
-func initHash(miner common.Address, blockHash common.Hash, nonce uint64) common.Hash {
+func initHash(miner common.Address, mixedHash common.Hash, nonce uint64) common.Hash {
 	return crypto.Keccak256Hash(
 		common.BytesToHash(miner.Bytes()).Bytes(),
-		blockHash.Bytes(),
+		mixedHash.Bytes(),
 		common.BigToHash(new(big.Int).SetUint64(nonce)).Bytes(),
 	)
 }

--- a/integration_tests/node_mine_test.go
+++ b/integration_tests/node_mine_test.go
@@ -141,6 +141,16 @@ func TestMining(t *testing.T) {
 }
 
 func cleanFiles(proverDir string) {
+	for _, shardId := range shardIds {
+		fileName := fmt.Sprintf(dataFileName, shardId)
+		if _, err := os.Stat(fileName); !os.IsNotExist(err) {
+			err = os.Remove(fileName)
+			if err != nil {
+				fmt.Println(err)
+			}
+		}
+	}
+
 	folderPath := filepath.Join(proverDir, "snarkbuild")
 	files, err := ioutil.ReadDir(folderPath)
 	if err != nil {

--- a/integration_tests/node_mine_test.go
+++ b/integration_tests/node_mine_test.go
@@ -74,7 +74,7 @@ func TestMining(t *testing.T) {
 	feed := new(event.Feed)
 
 	l1api := miner.NewL1MiningAPI(pClient, lg)
-	pvr := prover.NewKZGPoseidonProver(miningConfig.ZKWorkingDir, zkeyFile, 2, lg)
+	pvr := prover.NewKZGPoseidonProver(miningConfig.ZKWorkingDir, miningConfig.ZKeyFileName, 2, lg)
 	mnr := miner.New(miningConfig, storageManager, l1api, &pvr, feed, lg)
 	lg.Info("Initialized miner")
 
@@ -97,9 +97,10 @@ func TestMining(t *testing.T) {
 		}
 		lg.Error("L1 heads subscription error", "err", err)
 	}()
-	prepareData(t, pClient, storageManager, miningConfig.StorageCost.String())
-	// fillEmpty(t, pClient, storageManager)
+
 	mnr.Start()
+	prepareData(t, pClient, storageManager, miningConfig.StorageCost.String())
+	fillEmpty(t, pClient, storageManager)
 
 	var wg sync.WaitGroup
 	minedShardCh := make(chan uint64)
@@ -140,16 +141,6 @@ func TestMining(t *testing.T) {
 }
 
 func cleanFiles(proverDir string) {
-	for _, shardId := range shardIds {
-		fileName := fmt.Sprintf(dataFileName, shardId)
-		if _, err := os.Stat(fileName); !os.IsNotExist(err) {
-			err = os.Remove(fileName)
-			if err != nil {
-				fmt.Println(err)
-			}
-		}
-	}
-
 	folderPath := filepath.Join(proverDir, "snarkbuild")
 	files, err := ioutil.ReadDir(folderPath)
 	if err != nil {


### PR DESCRIPTION
Use RANDAO (`mixDigest` field of the block) as a random seed for hash computing, according to the change of https://github.com/ethstorage/storage-contracts-v1/pull/61.

Tested mining in integration tests with storage contract commit [9775efe](https://github.com/ethstorage/storage-contracts-v1/pull/61/commits/9775efe6fb84029434d87c530f8e5ba77c7ddcf5)

Gas used first time submit 493,167, later 463,305.

Copy old numbers from https://github.com/ethstorage/storage-contracts-v1/issues/20#issuecomment-1879472374 for comparison:

|Circuit|Gas|
|--|--|
|old|572,610|
|new|372,882|
