### PR TITLE
fix issue 201: Syncing time estimation is not accurate

### DIFF
--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -1187,7 +1187,7 @@ func (s *SyncClient) reportFillEmptyState() {
 		subFillTaskRemain = subFillTaskRemain + len(t.SubEmptyTasks)
 	}
 
-	etaFillSecondsLeft := totalSecondsUsed * emptyToFill / emptyFilled
+	etaSecondsLeft := totalSecondsUsed * emptyToFill / emptyFilled
 
 	// Create a mega progress report
 	var (
@@ -1197,7 +1197,7 @@ func (s *SyncClient) reportFillEmptyState() {
 	)
 	log.Info("Storage fill empty in progress", "progress", progress, "tasksRemain", tasksRemain,
 		"emptyFilled", blobsFilled, "emptyToFill", emptyToFill, "timeUsed", common.PrettyDuration(time.Duration(totalSecondsUsed)*time.Second),
-		"etaTimeLeft", common.PrettyDuration(time.Duration(etaFillSecondsLeft)*time.Second))
+		"etaTimeLeft", common.PrettyDuration(time.Duration(etaSecondsLeft)*time.Second))
 }
 
 func (s *SyncClient) ReportPeerSummary() {

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -1123,16 +1123,24 @@ func (s *SyncClient) report(force bool) {
 	s.totalSecondsUsed = s.totalSecondsUsed + uint64(time.Since(s.logTime).Seconds())
 	s.logTime = time.Now()
 
+	s.reportSyncState()
+	s.reportFillEmptyState()
+}
+
+func (s *SyncClient) reportSyncState() {
 	// Don't report anything until we have a meaningful progress
-	synced, syncedBytes := s.blobsSynced, s.syncedBytes
-	emptyFilled, emptyToFill := s.emptyBlobsFilled, s.emptyBlobsToFill
-	totalSecondsUsed, peerCount := s.totalSecondsUsed, len(s.peers)
-	filledBytes := common.StorageSize(emptyFilled * s.storageManager.MaxKvSize())
-	if synced == 0 && emptyFilled == 0 {
+	if s.blobsSynced == 0 {
 		return
 	}
-	blobsToSync := uint64(0)
-	taskRemain, subTaskRemain, subFillTaskRemain := 0, 0, 0
+	var (
+		totalSecondsUsed = s.totalSecondsUsed
+		synced           = s.blobsSynced
+		syncedBytes      = s.syncedBytes
+		blobsToSync      = uint64(0)
+		taskRemain       = 0
+		subTaskRemain    = 0
+	)
+
 	for _, t := range s.tasks {
 		for _, st := range t.SubTasks {
 			blobsToSync = blobsToSync + (st.Last - st.next)
@@ -1142,22 +1150,54 @@ func (s *SyncClient) report(force bool) {
 		if !t.done {
 			taskRemain++
 		}
-		subFillTaskRemain = subFillTaskRemain + len(t.SubEmptyTasks)
 	}
 
-	etaSecondsLeft := totalSecondsUsed * (blobsToSync + emptyToFill) / (synced + emptyFilled)
+	etaSecondsLeft := totalSecondsUsed * blobsToSync / synced
 
 	// Create a mega progress report
 	var (
-		progress        = fmt.Sprintf("%.2f%%", float64(synced+emptyFilled)*100/float64(blobsToSync+synced+emptyFilled+emptyToFill))
-		syncTasksRemain = fmt.Sprintf("%d@%d", taskRemain, subTaskRemain)
-		blobsSynced     = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(synced), syncedBytes.TerminalString())
-		blobsFilled     = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(emptyFilled), filledBytes.TerminalString())
+		progress    = fmt.Sprintf("%.2f%%", float64(synced)*100/float64(blobsToSync+synced))
+		tasksRemain = fmt.Sprintf("%d@%d", taskRemain, subTaskRemain)
+		blobsSynced = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(synced), syncedBytes.TerminalString())
 	)
-	log.Info("Storage sync in progress", "progress", progress, "peerCount", peerCount, "syncTasksRemain", syncTasksRemain,
-		"blobsSynced", blobsSynced, "blobsToSync", blobsToSync, "fillTasksRemain", subFillTaskRemain,
-		"emptyFilled", blobsFilled, "emptyToFill", emptyToFill, "timeUsed", common.PrettyDuration(time.Duration(totalSecondsUsed)*time.Second),
+	log.Info("Storage sync in progress", "progress", progress, "peerCount", len(s.peers), "tasksRemain", tasksRemain,
+		"blobsSynced", blobsSynced, "blobsToSync", blobsToSync, "timeUsed", common.PrettyDuration(time.Duration(totalSecondsUsed)*time.Second),
 		"etaTimeLeft", common.PrettyDuration(time.Duration(etaSecondsLeft)*time.Second))
+}
+
+func (s *SyncClient) reportFillEmptyState() {
+	// Don't report anything until we have a meaningful progress
+	if s.emptyBlobsFilled == 0 {
+		return
+	}
+
+	var (
+		totalSecondsUsed  = s.totalSecondsUsed
+		emptyFilled       = s.emptyBlobsFilled
+		filledBytes       = common.StorageSize(s.emptyBlobsFilled * s.storageManager.MaxKvSize())
+		emptyToFill       = s.emptyBlobsToFill
+		taskRemain        = 0
+		subFillTaskRemain = 0
+	)
+
+	for _, t := range s.tasks {
+		if !t.done {
+			taskRemain++
+		}
+		subFillTaskRemain = subFillTaskRemain + len(t.SubEmptyTasks)
+	}
+
+	etaFillSecondsLeft := totalSecondsUsed * emptyToFill / emptyFilled
+
+	// Create a mega progress report
+	var (
+		progress    = fmt.Sprintf("%.2f%%", float64(emptyFilled)*100/float64(emptyFilled+emptyToFill))
+		tasksRemain = fmt.Sprintf("%d@%d", taskRemain, subFillTaskRemain)
+		blobsFilled = fmt.Sprintf("%v@%v", log.FormatLogfmtUint64(emptyFilled), filledBytes.TerminalString())
+	)
+	log.Info("Storage fill empty in progress", "progress", progress, "tasksRemain", tasksRemain,
+		"emptyFilled", blobsFilled, "emptyToFill", emptyToFill, "timeUsed", common.PrettyDuration(time.Duration(totalSecondsUsed)*time.Second),
+		"etaTimeLeft", common.PrettyDuration(time.Duration(etaFillSecondsLeft)*time.Second))
 }
 
 func (s *SyncClient) ReportPeerSummary() {


### PR DESCRIPTION
issue 201: https://github.com/ethstorage/es-node/issues/201

The data syncing and filling-empty speeds may vary significantly, so calculating their respective times would provide a more accurate estimate. This change split the state report into two parts -- sync process and fill empty process. 

How to test:
Run the es-node and see the sync state like the following.
```
INFO [02-05|04:23:44.659] Storage sync in progress                 progress=0.50% peerCount=6 tasksRemain=1@32 blobsSynced=5824@728.00MiB blobsToSync=1,150,778 timeUsed=2m32s etaTimeLeft=8h20m34s
INFO [02-05|04:23:44.659] Storage fill empty in progress           progress=0.54% tasksRemain=1@30 emptyFilled=16368@2.00GiB  emptyToFill=3,021,334 timeUsed=2m32s etaTimeLeft=7h47m37s
```