### PR TITLE
Fix build on Ubuntu 20.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ es-node: build
 	mkdir -p build/bin/snarkbuild
 
 build:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o build/bin/es-node ./cmd/es-node/
+	env GO111MODULE=on CGO_ENABLED=0 GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o build/bin/es-node ./cmd/es-node/
 
 clean:
 	rm -r build


### PR DESCRIPTION
Addressing https://github.com/ethstorage/es-node/issues/239

Possible cause: the build was created on a newer version of ubuntu than 20.04 where some dependencies are dynamically linked (GLIBC_2.32, GLIBC_2.34)

Solution:

With CGO_ENABLED=0 you got a statically-linked binary (see: https://en.wikipedia.org/wiki/Static_build) so it will run without any external dependencies

Test has been done on ubuntu 20.04 and 22.04: running es-node till successfully mined.