### PR TITLE
fix issue: es-node cannot stop by ctrl + c

### DIFF
--- a/ethstorage/p2p/node.go
+++ b/ethstorage/p2p/node.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
-	"strconv"
-	"time"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
@@ -26,6 +22,8 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	ma "github.com/multiformats/go-multiaddr"
+	"net"
+	"strconv"
 )
 
 // NodeP2P is a p2p node, which can be used to gossip messages.
@@ -194,7 +192,7 @@ func (n *NodeP2P) RequestL2Range(ctx context.Context, start, end uint64) (uint64
 // RequestShardList fetches shard list from remote peer
 func (n *NodeP2P) RequestShardList(remotePeer peer.ID) ([]*protocol.ContractShards, error) {
 	remoteShardList := make([]*protocol.ContractShards, 0)
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), protocol.NewStreamTimeout)
 	s, err := n.Host().NewStream(ctx, remotePeer, protocol.RequestShardList)
 	if err != nil {
 		return remoteShardList, err

--- a/ethstorage/p2p/node.go
+++ b/ethstorage/p2p/node.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"strconv"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
@@ -22,8 +25,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	ma "github.com/multiformats/go-multiaddr"
-	"net"
-	"strconv"
 )
 
 // NodeP2P is a p2p node, which can be used to gossip messages.

--- a/ethstorage/p2p/node.go
+++ b/ethstorage/p2p/node.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -193,7 +194,8 @@ func (n *NodeP2P) RequestL2Range(ctx context.Context, start, end uint64) (uint64
 // RequestShardList fetches shard list from remote peer
 func (n *NodeP2P) RequestShardList(remotePeer peer.ID) ([]*protocol.ContractShards, error) {
 	remoteShardList := make([]*protocol.ContractShards, 0)
-	s, err := n.Host().NewStream(context.Background(), remotePeer, protocol.RequestShardList)
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	s, err := n.Host().NewStream(ctx, remotePeer, protocol.RequestShardList)
 	if err != nil {
 		return remoteShardList, err
 	}

--- a/ethstorage/p2p/node.go
+++ b/ethstorage/p2p/node.go
@@ -193,7 +193,9 @@ func (n *NodeP2P) RequestL2Range(ctx context.Context, start, end uint64) (uint64
 // RequestShardList fetches shard list from remote peer
 func (n *NodeP2P) RequestShardList(remotePeer peer.ID) ([]*protocol.ContractShards, error) {
 	remoteShardList := make([]*protocol.ContractShards, 0)
-	ctx, _ := context.WithTimeout(context.Background(), protocol.NewStreamTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), protocol.NewStreamTimeout)
+	defer cancel()
+
 	s, err := n.Host().NewStream(ctx, remotePeer, protocol.RequestShardList)
 	if err != nil {
 		return remoteShardList, err

--- a/ethstorage/p2p/protocol/peer.go
+++ b/ethstorage/p2p/protocol/peer.go
@@ -91,7 +91,8 @@ func (p *Peer) RequestBlobsByRange(id uint64, contract common.Address, shardId u
 	p.logger.Trace("Fetching KVs", "reqId", id, "contract", contract,
 		"shardId", shardId, "origin", origin, "limit", limit)
 
-	stream, err := p.newStreamFn(p.resCtx, p.id, GetProtocolID(RequestBlobsByRangeProtocolID, p.chainId))
+	ctx, _ := context.WithTimeout(p.resCtx, NewStreamTimeout)
+	stream, err := p.newStreamFn(ctx, p.id, GetProtocolID(RequestBlobsByRangeProtocolID, p.chainId))
 	if err != nil {
 		return clientError, err
 	}
@@ -117,7 +118,8 @@ func (p *Peer) RequestBlobsByList(id uint64, contract common.Address, shardId ui
 	p.logger.Trace("Fetching KVs", "reqId", id, "contract", contract,
 		"shardId", shardId, "count", len(kvList))
 
-	stream, err := p.newStreamFn(p.resCtx, p.id, GetProtocolID(RequestBlobsByListProtocolID, p.chainId))
+	ctx, _ := context.WithTimeout(p.resCtx, NewStreamTimeout)
+	stream, err := p.newStreamFn(ctx, p.id, GetProtocolID(RequestBlobsByListProtocolID, p.chainId))
 	if err != nil {
 		return clientError, err
 	}

--- a/ethstorage/p2p/protocol/peer.go
+++ b/ethstorage/p2p/protocol/peer.go
@@ -91,7 +91,9 @@ func (p *Peer) RequestBlobsByRange(id uint64, contract common.Address, shardId u
 	p.logger.Trace("Fetching KVs", "reqId", id, "contract", contract,
 		"shardId", shardId, "origin", origin, "limit", limit)
 
-	ctx, _ := context.WithTimeout(p.resCtx, NewStreamTimeout)
+	ctx, cancel := context.WithTimeout(p.resCtx, NewStreamTimeout)
+	defer cancel()
+
 	stream, err := p.newStreamFn(ctx, p.id, GetProtocolID(RequestBlobsByRangeProtocolID, p.chainId))
 	if err != nil {
 		return clientError, err
@@ -118,7 +120,9 @@ func (p *Peer) RequestBlobsByList(id uint64, contract common.Address, shardId ui
 	p.logger.Trace("Fetching KVs", "reqId", id, "contract", contract,
 		"shardId", shardId, "count", len(kvList))
 
-	ctx, _ := context.WithTimeout(p.resCtx, NewStreamTimeout)
+	ctx, cancel := context.WithTimeout(p.resCtx, NewStreamTimeout)
+	defer cancel()
+
 	stream, err := p.newStreamFn(ctx, p.id, GetProtocolID(RequestBlobsByListProtocolID, p.chainId))
 	if err != nil {
 		return clientError, err

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -38,9 +38,11 @@ const (
 	// timeout for writing the request as client. Can be as long as serverReadRequestTimeout
 	clientWriteRequestTimeout = time.Second * 10
 	// timeout for reading a response of a serving peer as client. Can be as long as serverWriteChunkTimeout
-	clientReadResponsetimeout = time.Second * 10
+	clientReadResponseTimeout = time.Second * 10
 	// after the rate-limit reservation hits the max throttle delay, give up on serving a request and just close the stream
 	maxThrottleDelay = time.Second * 20
+
+	NewStreamTimeout = time.Second * 15
 
 	defaultMaxPeerCount = 30
 

--- a/ethstorage/p2p/protocol/utils.go
+++ b/ethstorage/p2p/protocol/utils.go
@@ -49,7 +49,7 @@ func WriteMsg(stream network.Stream, msg *Msg) error {
 }
 
 func ReadMsg(stream network.Stream) ([]byte, byte, error) {
-	_ = stream.SetReadDeadline(time.Now().Add(clientReadResponsetimeout))
+	_ = stream.SetReadDeadline(time.Now().Add(clientReadResponseTimeout))
 	var returnCode [1]byte
 	if _, err := io.ReadFull(stream, returnCode[:]); err != nil {
 		return nil, clientError, fmt.Errorf("failed to read result part of response: %w", err)


### PR DESCRIPTION
issue https://github.com/ethstorage/es-node/issues/237

### Expected behaviour
After ctrl + c, the es-node should output "Storage node exited" and stop in a few seconds.

### Reason
The es-node cannot stop because "host" in NodeP2P failed to stop, that is due to StopNotify in host.Close() blocked by failed to get s.notifs.Lock(). the lock (read lock) is held by notifyAll which calls all the function register through Network.Notify(). And RequestShardList() in the add connection notify function would wait and block the lock, and that is because n.Host().NewStream in that function does not have timeout control. 

github.com\libp2p\go-libp2p\p2p\net\swarm\swarm.go
// StopNotify unregisters Notifiee fromr receiving signals
func (s *Swarm) StopNotify(f network.Notifiee) {
s.notifs.Lock()
delete(s.notifs.m, f)
s.notifs.Unlock()
}

github.com/ethstorage/es-node/ethstorage/p2p/node.go
n.host.Network().Notify(
... ...
RequestShardList()
... ...
)

func (n *NodeP2P) RequestShardList(remotePeer peer.ID) ([]*protocol.ContractShards, error) {
	... ...
	s, err := n.Host().NewStream(context.Background(), remotePeer, protocol.RequestShardList)
        ... ...
}

How to fix
Add timeout control to n.Host().NewStream function.

How to test
Run es-node for some time, and then ctrl+c, the es-node should finish in a few seconds.
env ES_NODE_STORAGE_MINER= ES_NODE_SIGNER_PRIVATE_KEY= ./run.sh