### PR TITLE
Reduce log-levels to reduce user confusion

### DIFF
--- a/ethstorage/p2p/discovery.go
+++ b/ethstorage/p2p/discovery.go
@@ -303,7 +303,7 @@ func (n *NodeP2P) DiscoveryProcess(ctx context.Context, log log.Logger, l1ChainI
 				if updateLocalNodeIPAndTCP(n.host.Addrs(), n.dv5Local) && !initialized {
 					initialized = true
 					updateLocalNodeTicker.Reset(refreshLocalNodeAddrInterval)
-					log.Info("Update TCP IP address", "ip", n.dv5Local.Node().IP(), "udp", n.dv5Local.Node().UDP(),
+					log.Info("Update local TCP IP address", "ip", n.dv5Local.Node().IP(), "udp", n.dv5Local.Node().UDP(),
 						"tcp", n.dv5Local.Node().TCP(), "seq", n.dv5Local.Seq(), "enr", n.dv5Local.Node().String())
 				}
 			case <-ctx.Done():
@@ -374,7 +374,7 @@ func (n *NodeP2P) DiscoveryProcess(ctx context.Context, log log.Logger, l1ChainI
 			// get the most recent version of the node record in case it change deal to the remote node TCP or UDP port change.
 			node := n.dv5Udp.Resolve(found)
 			if node.Seq() != found.Seq() {
-				log.Info("Remote node ENR changed", "ID", node.ID(), "remote IP", node.IP(), "ENR", node.String())
+				log.Debug("Remote node ENR changed", "ID", node.ID(), "remote IP", node.IP(), "ENR", node.String())
 			}
 			var dat protocol.EthStorageENRData
 			if err := node.Load(&dat); err != nil { // we already filtered on chain ID and Version
@@ -389,7 +389,7 @@ func (n *NodeP2P) DiscoveryProcess(ctx context.Context, log log.Logger, l1ChainI
 			pstore.AddAddrs(info.ID, info.Addrs, discoveredAddrTTL)
 			err = pstore.Put(info.ID, protocol.EthStorageENRKey, dat.Shards)
 			if err != nil {
-				log.Warn("Peerstore put EthStorageENRKey error", "err", err.Error())
+				log.Info("Peerstore put EthStorageENRKey error", "err", err.Error())
 				continue
 			}
 			_ = pstore.AddPubKey(info.ID, pub)

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -1072,7 +1072,7 @@ func (s *SyncClient) decodeKV(payload *BlobPayload) ([]byte, bool) {
 		payload.MinerAddress, payload.EncodeType)
 	if err != nil || !found {
 		if err != nil {
-			s.log.Info("Failed to decode", "kvIdx", payload.BlobIndex, "error", err)
+			s.log.Error("Failed to decode", "kvIdx", payload.BlobIndex, "error", err)
 		} else {
 			s.log.Info("Failed to decode", "kvIdx", payload.BlobIndex, "error", "not found")
 		}

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -1087,11 +1087,11 @@ func (s *SyncClient) checkBlobCommit(decodedBlob []byte, payload *BlobPayload) b
 	recordDur()
 
 	if err != nil {
-		s.log.Warn("Get proof fail", "idx", payload.BlobIndex, "err", err.Error())
+		s.log.Error("Get proof fail", "idx", payload.BlobIndex, "err", err.Error())
 		return false
 	}
 	if !bytes.Equal(root[:ethstorage.HashSizeInContract], payload.BlobCommit[:ethstorage.HashSizeInContract]) {
-		s.log.Warn("Compare blob failed", "idx", payload.BlobIndex, "err",
+		s.log.Info("Compare blob failed", "idx", payload.BlobIndex, "err",
 			fmt.Sprintf("verify blob fail: root: %s; MetaHash hash (24): %s, providerAddr %s, data len %d",
 				common.Bytes2Hex(root[:ethstorage.HashSizeInContract]), common.Bytes2Hex(payload.BlobCommit[:ethstorage.HashSizeInContract]),
 				payload.MinerAddress.Hex(), len(payload.EncodedBlob)))

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -463,7 +463,7 @@ func (s *SyncClient) Start() error {
 func (s *SyncClient) AddPeer(id peer.ID, shards map[common.Address][]uint64, direction network.Direction) bool {
 	s.lock.Lock()
 	if _, ok := s.peers[id]; ok {
-		s.log.Warn("Cannot register peer for sync duties, peer was already registered", "peer", id)
+		s.log.Debug("Cannot register peer for sync duties, peer was already registered", "peer", id)
 		s.lock.Unlock()
 		return true
 	}
@@ -496,7 +496,7 @@ func (s *SyncClient) RemovePeer(id peer.ID) {
 	defer s.lock.Unlock()
 	pr, ok := s.peers[id]
 	if !ok {
-		s.log.Info("Cannot remove peer from sync duties, peer was not registered", "peer", id)
+		s.log.Debug("Cannot remove peer from sync duties, peer was not registered", "peer", id)
 		return
 	}
 	pr.resCancel() // once loop exits
@@ -685,12 +685,12 @@ func (s *SyncClient) assignBlobRangeTasks() {
 				s.lock.Unlock()
 
 				if err != nil {
-					log.Warn("Failed to request blobs", "peer", pr.id.String(), "err", err)
+					log.Info("Failed to request blobs", "peer", pr.id.String(), "err", err)
 					return
 				}
 
 				if req.id != packet.ID || req.contract != packet.Contract || req.shardId != packet.ShardId {
-					log.Warn("Req mismatch with res", "reqId", req.id, "packetId", packet.ID,
+					log.Info("Req mismatch with res", "reqId", req.id, "packetId", packet.ID,
 						"reqContract", req.contract.Hex(), "packetContract", packet.Contract.Hex(),
 						"reqShardId", req.shardId, "packetShardId", packet.ShardId)
 					return
@@ -768,11 +768,11 @@ func (s *SyncClient) assignBlobHealTasks() {
 			s.lock.Unlock()
 
 			if err != nil {
-				log.Warn("Failed to request packet", "peer", pr.id.String(), "err", err)
+				log.Info("Failed to request packet", "peer", pr.id.String(), "err", err)
 				return
 			}
 			if req.id != packet.ID || req.contract != packet.Contract || req.shardId != packet.ShardId {
-				log.Warn("Req mismatch with res", "reqId", req.id, "packetId", packet.ID,
+				log.Info("Req mismatch with res", "reqId", req.id, "packetId", packet.ID,
 					"reqContract", req.contract.Hex(), "packetContract", packet.Contract.Hex(),
 					"reqShardId", req.shardId, "packetShardId", packet.ShardId)
 				return
@@ -890,7 +890,7 @@ func (s *SyncClient) OnBlobsByRange(res *blobsByRangeResponse) {
 	// the requested Data. For blob range queries that means the peer is not
 	// yet synced.
 	if len(blobsInRange) == 0 {
-		s.log.Warn("Peer rejected get blob by range request")
+		s.log.Info("Peer rejected get blob by range request")
 		s.lock.Lock()
 		if _, ok := s.peers[req.peer]; ok {
 			req.subTask.task.statelessPeers[req.peer] = struct{}{}
@@ -972,7 +972,7 @@ func (s *SyncClient) OnBlobsByList(res *blobsByListResponse) {
 	// the requested Data. For kv range queries that means the peer is not
 	// yet synced.
 	if len(blobsInRange) == 0 {
-		s.log.Warn("Peer rejected get blobs by list request")
+		s.log.Info("Peer rejected get blobs by list request")
 		s.lock.Lock()
 		if _, ok := s.peers[req.peer]; ok {
 			req.healTask.task.statelessPeers[req.peer] = struct{}{}
@@ -1072,9 +1072,9 @@ func (s *SyncClient) decodeKV(payload *BlobPayload) ([]byte, bool) {
 		payload.MinerAddress, payload.EncodeType)
 	if err != nil || !found {
 		if err != nil {
-			s.log.Error("Failed to decode", "kvIdx", payload.BlobIndex, "error", err)
+			s.log.Info("Failed to decode", "kvIdx", payload.BlobIndex, "error", err)
 		} else {
-			s.log.Error("Failed to decode", "kvIdx", payload.BlobIndex, "error", "not found")
+			s.log.Info("Failed to decode", "kvIdx", payload.BlobIndex, "error", "not found")
 		}
 		return []byte{}, false
 	}
@@ -1087,11 +1087,11 @@ func (s *SyncClient) checkBlobCommit(decodedBlob []byte, payload *BlobPayload) b
 	recordDur()
 
 	if err != nil {
-		s.log.Error("Get proof fail", "idx", payload.BlobIndex, "err", err.Error())
+		s.log.Warn("Get proof fail", "idx", payload.BlobIndex, "err", err.Error())
 		return false
 	}
 	if !bytes.Equal(root[:ethstorage.HashSizeInContract], payload.BlobCommit[:ethstorage.HashSizeInContract]) {
-		s.log.Error("Compare blob failed", "idx", payload.BlobIndex, "err",
+		s.log.Warn("Compare blob failed", "idx", payload.BlobIndex, "err",
 			fmt.Sprintf("verify blob fail: root: %s; MetaHash hash (24): %s, providerAddr %s, data len %d",
 				common.Bytes2Hex(root[:ethstorage.HashSizeInContract]), common.Bytes2Hex(payload.BlobCommit[:ethstorage.HashSizeInContract]),
 				payload.MinerAddress.Hex(), len(payload.EncodedBlob)))


### PR DESCRIPTION
Update rule: err caused by the remote peer, reduce the log level to info or debug.