### PR TITLE
Fix crashs: add lock ReportPeerSummary and check Peer is null in getIdlePeerForTask

### DIFF
--- a/ethstorage/p2p/protocol/peer.go
+++ b/ethstorage/p2p/protocol/peer.go
@@ -5,7 +5,6 @@ package protocol
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -55,16 +54,6 @@ func (p *Peer) Version() uint {
 
 func (p *Peer) Shards() map[common.Address][]uint64 {
 	return p.shards
-}
-
-// SetShards this should only be set when doing handshake.
-func (p *Peer) SetShards(shards map[common.Address][]uint64) error {
-	// shards can only be set once.
-	if p.shards != nil {
-		return fmt.Errorf("peer shards has been set multi times")
-	}
-	p.shards = shards
-	return nil
 }
 
 // IsShardExist checks whether one specific shard is supported by this peer.

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -1208,8 +1208,8 @@ func (s *SyncClient) ReportPeerSummary() {
 					outbound++
 				}
 			}
-			s.lock.Unlock()
 			log.Info("P2P Summary", "activePeers", len(s.peers), "inbound", inbound, "outbound", outbound)
+			s.lock.Unlock()
 		case <-s.resCtx.Done():
 			log.Info("P2P summary stop")
 			return


### PR DESCRIPTION
issue: https://github.com/ethstorage/es-node/issues/261
Fix crashs: add lock ReportPeerSummary and check Peer is null in getIdlePeerForTask

**1. The es-node crash with error log:**
{"log":"panic: runtime error: invalid memory address or nil pointer dereference\n","stream":"stderr","time":"2024-03-28T18:04:09.789901565Z"}
{"log":"[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0xe9fab8]\n","stream":"stderr","time":"2024-03-28T18:04:09.789909345Z"}
{"log":"\n","stream":"stderr","time":"2024-03-28T18:04:09.789911745Z"}
{"log":"goroutine 16820 [running]:\n","stream":"stderr","time":"2024-03-28T18:04:09.789913915Z"}
{"log":"github.com/ethstorage/go-ethstorage/ethstorage/p2p/protocol.(*Peer).IsShardExist(...)\n","stream":"stderr","time":"2024-03-28T18:04:09.789916125Z"}
{"log":"\u0009/es-node/ethstorage/p2p/protocol/peer.go:72\n","stream":"stderr","time":"2024-03-28T18:04:09.789918365Z"}
{"log":"github.com/ethstorage/go-ethstorage/ethstorage/p2p/protocol.(*SyncClient).getIdlePeerForTask(...)\n","stream":"stderr","time":"2024-03-28T18:04:09.789920765Z"}
{"log":"\u0009/es-node/ethstorage/p2p/protocol/syncclient.go:852\n","stream":"stderr","time":"2024-03-28T18:04:09.789940925Z"}
{"log":"github.com/ethstorage/go-ethstorage/ethstorage/p2p/protocol.(*SyncClient).assignBlobRangeTasks(0xc000ce0000)\n","stream":"stderr","time":"2024-03-28T18:04:09.789951475Z"}
{"log":"\u0009/es-node/ethstorage/p2p/protocol/syncclient.go:634 +0x618\n","stream":"stderr","time":"2024-03-28T18:04:09.789954945Z"}

**2. The es-node crash with error log:**
{"log":"fatal error: concurrent map iteration and map write\n","stream":"stderr","time":"2024-04-02T03:13:43.093555938Z"}
{"log":"t=2024-04-02T03:13:43+0000 lvl=info msg=\"Disconnected from peer\"                peer=16Uiu2HAmFtwUFP2Dt8WKYkMEMctKEEEdkaz1D16Ees7JfjHzKFot addr=/ip4/95.211.223.52/tcp/9222\n","stream":"stdout","time":"2024-04-02T03:13:43.093601929Z"}
{"log":"\n","stream":"stderr","time":"2024-04-02T03:13:43.09665928Z"}
{"log":"goroutine 16625 [running]:\n","stream":"stderr","time":"2024-04-02T03:13:43.096677406Z"}
{"log":"github.com/ethstorage/go-ethstorage/ethstorage/p2p/protocol.(*SyncClient).ReportPeerSummary(0xc000b6e000)\n","stream":"stderr","time":"2024-04-02T03:13:43.097436905Z"}
{"log":"\u0009/es-node/ethstorage/p2p/protocol/syncclient.go:1203 +0x305\n","stream":"stderr","time":"2024-04-02T03:13:43.097443399Z"}
{"log":"created by github.com/ethstorage/go-ethstorage/ethstorage/p2p.(*NodeP2P).init\n","stream":"stderr","time":"2024-04-02T03:13:43.097769908Z"}
{"log":"\u0009/es-node/ethstorage/p2p/node.go:150 +0x83c\n","stream":"stderr","time":"2024-04-02T03:13:43.097774872Z"}
{"log":"\n","stream":"stderr","time":"2024-04-02T03:13:43.097779207Z"}
{"log":"goroutine 1 [chan receive, 3304 minutes]:\n","stream":"stderr","time":"2024-04-02T03:13:43.097786367Z"}
{"log":"main.EsNodeMain(0xc000384160?)\n","stream":"stderr","time":"2024-04-02T03:13:43.097792546Z"}
{"log":"\u0009/es-node/cmd/es-node/main.go:170 +0x937\n","stream":"stderr","time":"2024-04-02T03:13:43.097799444Z"}
{"log":"github.com/urfave/cli.HandleAction({0x13f3320?, 0x1f14fb8?}, 0xc000202380?)\n","stream":"stderr","time":"2024-04-02T03:13:43.097924904Z"}
{"log":"\u0009/go/pkg/mod/github.com/urfave/cli@v1.22.9/app.go:524 +0x50\n","stream":"stderr","time":"2024-04-02T03:13:43.09795417Z"}
{"log":"github.com/urfave/cli.(*App).Run(0xc000202380, {0xc000138000, 0x22, 0x24})\n","stream":"stderr","time":"2024-04-02T03:13:43.097961238Z"}
{"log":"\u0009/go/pkg/mod/github.com/urfave/cli@v1.22.9/app.go:286 +0x7bb\n","stream":"stderr","time":"2024-04-02T03:13:43.097965925Z"}
{"log":"main.main()\n","stream":"stderr","time":"2024-04-02T03:13:43.097970521Z"}
{"log":"\u0009/es-node/cmd/es-node/main.go:102 +0x599\n","stream":"stderr","time":"2024-04-02T03:13:43.09797495Z"}