### PR TITLE
bug fix - PeerCount is not correct when es-node restart.

### DIFF
--- a/ethstorage/metrics/network_metrics.go
+++ b/ethstorage/metrics/network_metrics.go
@@ -143,7 +143,7 @@ func (m *NetworkMetrics) SetStaticMetrics(peersTotal int, minerOfShards map[uint
 
 func (m *NetworkMetrics) DeletePeerInfo(id, version, address string, shardId uint64, miner common.Address) {
 	types := []string{"UpdateTime", "PeerCount", "SyncProgress", "SyncedSeconds", "FillEmptyProgress", "FillEmptySeconds",
-		"MiningPower", "SamplingTime", "Succeeded", "Failed", "Dropped", "LastSucceededTime"}
+		"MiningPower", "SamplingTime", "Succeeded", "Failed", "Dropped", "LastSucceededTime", "ProvidedBlobs"}
 	for _, t := range types {
 		m.PeerState.DeleteLabelValues(fmt.Sprintf(format, id, version, address, shardId, miner.Hex()), t)
 	}

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -272,6 +272,7 @@ func (s *SyncClient) loadSyncStatus() {
 			if t.Contract == s.storageManager.ContractAddress() && t.ShardId == sid {
 				if states != nil {
 					if state, ok := states[t.ShardId]; ok {
+						state.PeerCount = 0
 						t.state = state
 					}
 				}


### PR DESCRIPTION
1. For removed nodes, their metrics should be removed from the http://65.109.63.154:9500/, currently all metrics except "ProvidedBlobs" have been removed. "ProvidedBlobs" need to be removed also.
2. When es-node restarts, their state with peerCount will load from DB, but it should be reset to 0 and increased again when new peers join.