### PR TITLE
fix Issue232: Use dynamically adjusted request size to fetch blobs data from peers through p2p instread of using the static p2p.max.request.size value

### DIFF
--- a/ethstorage/flags/p2p_flags.go
+++ b/ethstorage/flags/p2p_flags.go
@@ -155,8 +155,8 @@ var (
 	InitRequestSize = cli.Uint64Flag{
 		Name: "p2p.request.size",
 		Usage: "p2p request size is the initial number of bytes to request from a remote peer. The default value is 1 * 1024 * 1024. " +
-			"It is value should not larger than 8 * 1024 * 1024. The request size will be changed according to network condition between the remote peer" +
-			"and the localnode, you can increase the max request size to improve the sync performance.",
+			"It is value should not larger than 8 * 1024 * 1024. The request size will be changed according to network condition " +
+			"between the remote peer and the local node.",
 		Required: false,
 		Value:    1 * 1024 * 1024,
 		EnvVar:   p2pEnv("MAX_REQUEST_SIZE"),

--- a/ethstorage/flags/p2p_flags.go
+++ b/ethstorage/flags/p2p_flags.go
@@ -153,10 +153,10 @@ var (
 		EnvVar:   p2pEnv("SECURITY"),
 	}
 	MaxRequestSize = cli.Uint64Flag{
-		Name: "p2p.max.request.size",
-		Usage: "max request size is the maximum number of bytes to request from a remote peer. The default value is 1 * 1024 * 1024. " +
-			"It is value should not larger than 8 * 1024 * 1024. if you have good network condition, " +
-			"you can increase the max request size to improve the sync performance.",
+		Name: "p2p.request.size",
+		Usage: "p2p request size is the initial number of bytes to request from a remote peer. The default value is 1 * 1024 * 1024. " +
+			"It is value should not larger than 8 * 1024 * 1024. The request size will be changed according to network condition between the remote peer" +
+			"and the localnode, you can increase the max request size to improve the sync performance.",
 		Required: false,
 		Value:    1 * 1024 * 1024,
 		EnvVar:   p2pEnv("MAX_REQUEST_SIZE"),

--- a/ethstorage/flags/p2p_flags.go
+++ b/ethstorage/flags/p2p_flags.go
@@ -152,7 +152,7 @@ var (
 		Value:    "noise",
 		EnvVar:   p2pEnv("SECURITY"),
 	}
-	MaxRequestSize = cli.Uint64Flag{
+	InitRequestSize = cli.Uint64Flag{
 		Name: "p2p.request.size",
 		Usage: "p2p request size is the initial number of bytes to request from a remote peer. The default value is 1 * 1024 * 1024. " +
 			"It is value should not larger than 8 * 1024 * 1024. The request size will be changed according to network condition between the remote peer" +
@@ -345,7 +345,7 @@ var p2pFlags = []cli.Flag{
 	StaticPeers,
 	HostMux,
 	HostSecurity,
-	MaxRequestSize,
+	InitRequestSize,
 	SyncConcurrency,
 	FillEmptyConcurrency,
 	MetaDownloadBatchSize,

--- a/ethstorage/p2p/cli/load_config.go
+++ b/ethstorage/p2p/cli/load_config.go
@@ -363,7 +363,7 @@ func loadGossipOptions(conf *p2p.Config, ctx *cli.Context) error {
 // loadSyncerParams loads [protocol.SyncerParams] from the CLI context.
 func loadSyncerParams(conf *p2p.Config, ctx *cli.Context) error {
 	metaDownloadBatchSize := ctx.GlobalUint64(flags.MetaDownloadBatchSize.Name)
-	maxRequestSize := ctx.GlobalUint64(flags.MaxRequestSize.Name)
+	initRequestSize := ctx.GlobalUint64(flags.InitRequestSize.Name)
 	syncConcurrency := ctx.GlobalUint64(flags.SyncConcurrency.Name)
 	fillEmptyConcurrency := ctx.GlobalInt(flags.FillEmptyConcurrency.Name)
 	maxPeers := ctx.GlobalInt(flags.PeersHi.Name)
@@ -372,7 +372,7 @@ func loadSyncerParams(conf *p2p.Config, ctx *cli.Context) error {
 	}
 	conf.SyncParams = &protocol.SyncerParams{
 		MaxPeers:              maxPeers,
-		MaxRequestSize:        maxRequestSize,
+		InitRequestSize:       initRequestSize,
 		SyncConcurrency:       syncConcurrency,
 		FillEmptyConcurrency:  fillEmptyConcurrency,
 		MetaDownloadBatchSize: metaDownloadBatchSize,

--- a/ethstorage/p2p/protocol/peer.go
+++ b/ethstorage/p2p/protocol/peer.go
@@ -77,7 +77,7 @@ func (p *Peer) Log() log.Logger {
 	return p.logger
 }
 
-func (p *Peer) getReqestSize() uint64 {
+func (p *Peer) getRequestSize() uint64 {
 	return uint64(p.tracker.Capacity(expectRequestTime))
 }
 
@@ -100,7 +100,7 @@ func (p *Peer) RequestBlobsByRange(id uint64, contract common.Address, shardId u
 		}
 	}()
 
-	requestSize := p.getReqestSize()
+	requestSize := p.getRequestSize()
 	return SendRPC(stream, &GetBlobsByRangePacket{
 		ID:       id,
 		Contract: contract,
@@ -130,7 +130,7 @@ func (p *Peer) RequestBlobsByList(id uint64, contract common.Address, shardId ui
 		}
 	}()
 
-	requestSize := p.getReqestSize()
+	requestSize := p.getRequestSize()
 	return SendRPC(stream, &GetBlobsByListPacket{
 		ID:       id,
 		Contract: contract,

--- a/ethstorage/p2p/protocol/peer.go
+++ b/ethstorage/p2p/protocol/peer.go
@@ -78,7 +78,7 @@ func (p *Peer) Log() log.Logger {
 }
 
 func (p *Peer) getReqestSize() uint64 {
-	return uint64(p.tracker.Capacity(expectRequestTime)) * blobSize
+	return uint64(p.tracker.Capacity(expectRequestTime))
 }
 
 // RequestBlobsByRange fetches a batch of kvs using a list of kv index

--- a/ethstorage/p2p/protocol/peer.go
+++ b/ethstorage/p2p/protocol/peer.go
@@ -101,7 +101,6 @@ func (p *Peer) RequestBlobsByRange(id uint64, contract common.Address, shardId u
 	}()
 
 	requestSize := p.getReqestSize()
-	p.logger.Warn("get request size fro RequestBlobsByRange", "request size", requestSize)
 	return SendRPC(stream, &GetBlobsByRangePacket{
 		ID:       id,
 		Contract: contract,
@@ -132,7 +131,6 @@ func (p *Peer) RequestBlobsByList(id uint64, contract common.Address, shardId ui
 	}()
 
 	requestSize := p.getReqestSize()
-	p.logger.Warn("get request size fro RequestBlobsByList", "request size", requestSize)
 	return SendRPC(stream, &GetBlobsByListPacket{
 		ID:       id,
 		Contract: contract,

--- a/ethstorage/p2p/protocol/peer.go
+++ b/ethstorage/p2p/protocol/peer.go
@@ -29,7 +29,7 @@ type Peer struct {
 
 // NewPeer create a wrapper for a network connection and negotiated  protocol version.
 func NewPeer(version uint, chainId *big.Int, peerId peer.ID, newStream newStreamFn, direction network.Direction,
-	initRequestSize float64, shards map[common.Address][]uint64) *Peer {
+	initRequestSize, minRequestSize uint64, shards map[common.Address][]uint64) *Peer {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Peer{
 		id:          peerId,
@@ -38,7 +38,7 @@ func NewPeer(version uint, chainId *big.Int, peerId peer.ID, newStream newStream
 		direction:   direction,
 		version:     version,
 		shards:      shards,
-		tracker:     NewTracker(peerId.String(), initRequestSize/(p2pReadWriteTimeout.Seconds()*rttEstimateFactor)),
+		tracker:     NewTracker(peerId.String(), float64(initRequestSize)/(p2pReadWriteTimeout.Seconds()*rttEstimateFactor), float64(minRequestSize)),
 		resCtx:      ctx,
 		resCancel:   cancel,
 		logger:      log.New("peer", peerId[:8]),

--- a/ethstorage/p2p/protocol/peer.go
+++ b/ethstorage/p2p/protocol/peer.go
@@ -38,7 +38,7 @@ func NewPeer(version uint, chainId *big.Int, peerId peer.ID, newStream newStream
 		direction:   direction,
 		version:     version,
 		shards:      shards,
-		tracker:     NewTracker(initRequestSize / expectRequestTime.Seconds()),
+		tracker:     NewTracker(peerId.String(), initRequestSize/expectRequestTime.Seconds()),
 		resCtx:      ctx,
 		resCancel:   cancel,
 		logger:      log.New("peer", peerId[:8]),
@@ -78,7 +78,7 @@ func (p *Peer) Log() log.Logger {
 }
 
 func (p *Peer) getReqestSize() uint64 {
-	return uint64(p.tracker.capacity * expectRequestTime.Seconds())
+	return uint64(p.tracker.Capacity(expectRequestTime))
 }
 
 // RequestBlobsByRange fetches a batch of kvs using a list of kv index
@@ -101,6 +101,7 @@ func (p *Peer) RequestBlobsByRange(id uint64, contract common.Address, shardId u
 	}()
 
 	requestSize := p.getReqestSize()
+	p.logger.Warn("get request size fro RequestBlobsByRange", "request size", requestSize)
 	return SendRPC(stream, &GetBlobsByRangePacket{
 		ID:       id,
 		Contract: contract,
@@ -131,6 +132,7 @@ func (p *Peer) RequestBlobsByList(id uint64, contract common.Address, shardId ui
 	}()
 
 	requestSize := p.getReqestSize()
+	p.logger.Warn("get request size fro RequestBlobsByList", "request size", requestSize)
 	return SendRPC(stream, &GetBlobsByListPacket{
 		ID:       id,
 		Contract: contract,

--- a/ethstorage/p2p/protocol/peer.go
+++ b/ethstorage/p2p/protocol/peer.go
@@ -38,7 +38,7 @@ func NewPeer(version uint, chainId *big.Int, peerId peer.ID, newStream newStream
 		direction:   direction,
 		version:     version,
 		shards:      shards,
-		tracker:     NewTracker(peerId.String(), initRequestSize/expectRequestTime.Seconds()),
+		tracker:     NewTracker(peerId.String(), initRequestSize/(p2pReadWriteTimeout.Seconds()*rttEstimateFactor)),
 		resCtx:      ctx,
 		resCancel:   cancel,
 		logger:      log.New("peer", peerId[:8]),
@@ -78,7 +78,7 @@ func (p *Peer) Log() log.Logger {
 }
 
 func (p *Peer) getRequestSize() uint64 {
-	return uint64(p.tracker.Capacity(expectRequestTime))
+	return uint64(p.tracker.Capacity(p2pReadWriteTimeout.Seconds() * rttEstimateFactor))
 }
 
 // RequestBlobsByRange fetches a batch of kvs using a list of kv index

--- a/ethstorage/p2p/protocol/peer.go
+++ b/ethstorage/p2p/protocol/peer.go
@@ -78,7 +78,7 @@ func (p *Peer) Log() log.Logger {
 }
 
 func (p *Peer) getReqestSize() uint64 {
-	return uint64(p.tracker.Capacity(expectRequestTime))
+	return uint64(p.tracker.Capacity(expectRequestTime)) * blobSize
 }
 
 // RequestBlobsByRange fetches a batch of kvs using a list of kv index
@@ -108,7 +108,7 @@ func (p *Peer) RequestBlobsByRange(id uint64, contract common.Address, shardId u
 		ShardId:  shardId,
 		Origin:   origin,
 		Limit:    limit,
-		Size:     requestSize,
+		Bytes:    requestSize,
 	}, blobs)
 }
 
@@ -138,6 +138,6 @@ func (p *Peer) RequestBlobsByList(id uint64, contract common.Address, shardId ui
 		Contract: contract,
 		ShardId:  shardId,
 		BlobList: kvList,
-		Size:     requestSize,
+		Bytes:    requestSize,
 	}, blobs)
 }

--- a/ethstorage/p2p/protocol/rate.go
+++ b/ethstorage/p2p/protocol/rate.go
@@ -1,0 +1,171 @@
+package protocol
+
+import (
+	"errors"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// measurementImpact is the impact a single measurement has on a peer's final
+// capacity value. A value closer to 0 reacts slower to sudden network changes,
+// but it is also more stable against temporary hiccups. 0.1 worked well for
+// most of Ethereum's existence, so might as well go with it.
+const measurementImpact = 0.1
+
+// capacityOverestimation is the ratio of items to over-estimate when retrieving
+// a peer's capacity to avoid locking into a lower value due to never attempting
+// to fetch more than some local stable value.
+const capacityOverestimation = 1.01
+
+const expectRequestTimeFactor = 0.8
+
+// Tracker estimates the throughput capacity of a peer with regard to each data
+// type it can deliver. The goal is to dynamically adjust request sizes to max
+// out network throughput without overloading either the peer or th elocal node.
+//
+// By tracking in real time the latencies and bandiwdths peers exhibit for each
+// packet type, it's possible to prevent overloading by detecting a slowdown on
+// one type when another type is pushed too hard.
+//
+// Similarly, real time measurements also help avoid overloading the local net
+// connection if our peers would otherwise be capable to deliver more, but the
+// local link is saturated. In that case, the live measurements will force us
+// to reduce request sizes until the throughput gets stable.
+//
+// Lastly, message rate measurements allows us to detect if a peer is unsuaully
+// slow compared to other peers, in which case we can decide to keep it around
+// or free up the slot so someone closer.
+//
+// Since throughput tracking and estimation adapts dynamically to live network
+// conditions, it's fine to have multiple trackers locally track the same peer
+// in different subsystem. The throughput will simply be distributed across the
+// two trackers if both are highly active.
+type Tracker struct {
+	// capacity is the number of items retrievable per second of a given type.
+	// It is analogous to bandwidth, but we deliberately avoided using bytes
+	// as the unit, since serving nodes also spend a lot of time loading data
+	// from disk, which is linear in the number of items, but mostly constant
+	// in their sizes.
+	capacity float64
+
+	lock sync.RWMutex
+}
+
+// NewTracker creates a new message rate tracker for a specific peer.
+func NewTracker(cap float64) *Tracker {
+	return &Tracker{
+		capacity: cap,
+	}
+}
+
+// Capacity calculates the number of items the peer is estimated to be able to
+// retrieve within the alloted time slot. The method will round up any division
+// errors and will add an additional overestimation ratio on top. The reason for
+// overshooting the capacity is because certain message types might not increase
+// the load proportionally to the requested items, so fetching a bit more might
+// still take the same RTT. By forcefully overshooting by a small amount, we can
+// avoid locking into a lower-that-real capacity.
+func (t *Tracker) Capacity(targetRTT time.Duration) int {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	// Calculate the actual measured throughput
+	throughput := t.capacity * float64(targetRTT) / float64(time.Second)
+
+	// Return an overestimation to force the peer out of a stuck minima, adding
+	// +1 in case the item count is too low for the overestimator to dent
+	return roundCapacity(1 + capacityOverestimation*throughput)
+}
+
+// roundCapacity gives the integer value of a capacity.
+// The result fits int32, and is guaranteed to be positive.
+func roundCapacity(cap float64) int {
+	return int(math.Min(maxMessageSize, math.Max(1, math.Ceil(cap)))) // TODO
+}
+
+// Update modifies the peer's capacity values for a specific data type with a new
+// measurement. If the delivery is zero, the peer is assumed to have either timed
+// out or to not have the requested data, resulting in a slash to 0 capacity. This
+// avoids assigning the peer retrievals that it won't be able to honour.
+func (t *Tracker) Update(elapsed time.Duration, items int) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	// Otherwise update the throughput with a new measurement
+	if elapsed <= 0 {
+		elapsed = 1 // +1 (ns) to ensure non-zero divisor
+	}
+	measured := float64(items) / (float64(elapsed) / float64(time.Second))
+
+	t.capacity = (1-measurementImpact)*(t.capacity) + measurementImpact*measured
+}
+
+// Trackers is a set of message rate trackers across a number of peers with the
+// goal of aggregating certain measurements across the entire set for outlier
+// filtering and newly joining initialization.
+type Trackers struct {
+	trackers map[string]*Tracker
+
+	log  log.Logger
+	lock sync.RWMutex
+}
+
+// NewTrackers creates an empty set of trackers to be filled with peers.
+func NewTrackers(log log.Logger) *Trackers {
+	return &Trackers{
+		trackers: make(map[string]*Tracker),
+		log:      log,
+	}
+}
+
+// Track inserts a new tracker into the set.
+func (t *Trackers) Track(id string, tracker *Tracker) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if _, ok := t.trackers[id]; ok {
+		return errors.New("already tracking")
+	}
+	t.trackers[id] = tracker
+
+	return nil
+}
+
+// Untrack stops tracking a previously added peer.
+func (t *Trackers) Untrack(id string) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if _, ok := t.trackers[id]; !ok {
+		return errors.New("not tracking")
+	}
+	delete(t.trackers, id)
+	return nil
+}
+
+// Capacity is a helper function to access a specific tracker without having to
+// track it explicitly outside.
+func (t *Trackers) Capacity(id string, targetRTT time.Duration) int {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	tracker := t.trackers[id]
+	if tracker == nil {
+		return 1 // Unregister race, don't return 0, it's a dangerous number
+	}
+	return tracker.Capacity(targetRTT)
+}
+
+// Update is a helper function to access a specific tracker without having to
+// track it explicitly outside.
+func (t *Trackers) Update(id string, elapsed time.Duration, items int) {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	if tracker := t.trackers[id]; tracker != nil {
+		tracker.Update(elapsed, items)
+	}
+}

--- a/ethstorage/p2p/protocol/sync_test.go
+++ b/ethstorage/p2p/protocol/sync_test.go
@@ -42,7 +42,7 @@ const (
 var (
 	contract = common.HexToAddress("0x0000000000000000000000000000000003330001")
 	empty    = make([]byte, 0)
-	params   = SyncerParams{MaxPeers: 30, MaxRequestSize: uint64(4 * 1024 * 1024), SyncConcurrency: 16, FillEmptyConcurrency: 16, MetaDownloadBatchSize: 16}
+	params   = SyncerParams{MaxPeers: 30, InitRequestSize: uint64(4 * 1024 * 1024), SyncConcurrency: 16, FillEmptyConcurrency: 16, MetaDownloadBatchSize: 16}
 	testLog  = log.New("TestSync")
 	prover   = prv.NewKZGProver(testLog)
 )

--- a/ethstorage/p2p/protocol/sync_test.go
+++ b/ethstorage/p2p/protocol/sync_test.go
@@ -1046,7 +1046,7 @@ func TestAddPeerDuringSyncing(t *testing.T) {
 	}
 	remoteHost0 := createRemoteHost(t, ctx, rollupCfg, smr0, db, m, testLog)
 	connect(t, localHost, remoteHost0, shardMap, shardMap)
-	time.Sleep(2 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	if syncCl.syncDone {
 		t.Fatalf("sync state %v is not match with expected state %v, peer count %d", syncCl.syncDone, false, len(syncCl.peers))
@@ -1064,7 +1064,7 @@ func TestAddPeerDuringSyncing(t *testing.T) {
 	}
 	remoteHost1 := createRemoteHost(t, ctx, rollupCfg, smr1, db, m, testLog)
 	connect(t, localHost, remoteHost1, shardMap, shardMap)
-	checkStall(t, 3, mux, cancel)
+	checkStall(t, 4, mux, cancel)
 
 	if !syncCl.syncDone {
 		t.Fatalf("sync state %v is not match with expected state %v, peer count %d", syncCl.syncDone, true, len(syncCl.peers))
@@ -1182,7 +1182,7 @@ func TestAddPeerAfterSyncDone(t *testing.T) {
 	}
 	remoteHost0 := createRemoteHost(t, ctx, rollupCfg, smr0, db, m, testLog)
 	connect(t, localHost, remoteHost0, shardMap, shardMap)
-	checkStall(t, 3, mux, cancel)
+	checkStall(t, 4, mux, cancel)
 
 	if !syncCl.syncDone {
 		t.Fatalf("sync state %v is not match with expected state %v, peer count %d", syncCl.syncDone, true, len(syncCl.peers))

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -538,7 +538,7 @@ func (s *SyncClient) AddPeer(id peer.ID, shards map[common.Address][]uint64, dir
 		return false
 	}
 	// add new peer routine
-	pr := NewPeer(0, s.cfg.L2ChainID, id, s.newStreamFn, direction, float64(s.syncerParams.InitRequestSize), shards)
+	pr := NewPeer(0, s.cfg.L2ChainID, id, s.newStreamFn, direction, s.syncerParams.InitRequestSize, s.storageManager.MaxKvSize(), shards)
 	s.peers[id] = pr
 
 	s.idlerPeers[id] = struct{}{}

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -539,7 +539,7 @@ func (s *SyncClient) AddPeer(id peer.ID, shards map[common.Address][]uint64, dir
 	}
 	// add new peer routine
 	pr := NewPeer(0, s.cfg.L2ChainID, id, s.newStreamFn, direction,
-		float64(s.syncerParams.InitRequestSize)/float64(s.storageManager.MaxKvSize()), shards)
+		float64(s.syncerParams.InitRequestSize), shards)
 	s.peers[id] = pr
 
 	s.idlerPeers[id] = struct{}{}
@@ -765,7 +765,7 @@ func (s *SyncClient) assignBlobRangeTasks() {
 					Blobs: packet.Blobs,
 					time:  time.Now(),
 				}
-				pr.tracker.Update(time.Since(req.time), len(packet.Blobs))
+				pr.tracker.Update(time.Since(req.time), len(packet.Blobs)*int(s.storageManager.MaxKvSize()))
 				s.OnBlobsByRange(res)
 			}(pr.id)
 		}
@@ -853,7 +853,7 @@ func (s *SyncClient) assignBlobHealTasks() {
 				Blobs: packet.Blobs,
 				time:  time.Now(),
 			}
-			pr.tracker.Update(time.Since(req.time), len(packet.Blobs))
+			pr.tracker.Update(time.Since(req.time), len(packet.Blobs)*int(s.storageManager.MaxKvSize()))
 			s.OnBlobsByList(res)
 		}(pr.ID())
 	}

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -538,8 +538,7 @@ func (s *SyncClient) AddPeer(id peer.ID, shards map[common.Address][]uint64, dir
 		return false
 	}
 	// add new peer routine
-	pr := NewPeer(0, s.cfg.L2ChainID, id, s.newStreamFn, direction,
-		float64(s.syncerParams.InitRequestSize), shards)
+	pr := NewPeer(0, s.cfg.L2ChainID, id, s.newStreamFn, direction, float64(s.syncerParams.InitRequestSize), shards)
 	s.peers[id] = pr
 
 	s.idlerPeers[id] = struct{}{}
@@ -688,7 +687,7 @@ func (s *SyncClient) assignBlobRangeTasks() {
 
 	// Iterate over all the tasks and try to find a pending one
 	for _, t := range s.tasks {
-		maxRange := s.syncerParams.InitRequestSize / ethstorage.ContractToShardManager[t.Contract].MaxKvSize() * 2
+		maxRange := maxRequestSize / ethstorage.ContractToShardManager[t.Contract].MaxKvSize() * 2
 		subTaskCount := len(t.SubTasks)
 		for idx := 0; idx < subTaskCount; idx++ {
 			pr := s.getIdlePeerForTask(t)
@@ -784,7 +783,7 @@ func (s *SyncClient) assignBlobHealTasks() {
 	// Iterate over all the tasks and try to find a pending one
 	for _, t := range s.tasks {
 		// All the kvs are downloading, wait for request time or success
-		batch := s.syncerParams.InitRequestSize / ethstorage.ContractToShardManager[t.Contract].MaxKvSize() * 2
+		batch := maxRequestSize / ethstorage.ContractToShardManager[t.Contract].MaxKvSize() * 2
 
 		// kvHealTask pending retrieval, try to find an idle peer. If no such peer
 		// exists, we probably assigned tasks for all (or they are stateless).

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -929,7 +929,7 @@ func (s *SyncClient) getIdlePeerForTask(t *task) *Peer {
 		return nil
 	}
 	sort.Sort(sort.Reverse(idlers))
-
+	log.Warn("list capacity after sort", "list", fmt.Sprintf("%v", idlers.caps))
 	return s.peers[idlers.ids[0]]
 }
 

--- a/ethstorage/p2p/protocol/syncserver.go
+++ b/ethstorage/p2p/protocol/syncserver.go
@@ -203,7 +203,7 @@ func (srv *SyncServer) handleGetBlobsByRangeRequest(ctx context.Context, stream 
 		sucRead++
 		res.Blobs = append(res.Blobs, payload)
 		readBytes += uint64(len(payload.EncodedBlob))
-		if readBytes >= req.Bytes || readBytes >= maxMessageSize {
+		if uint64(len(res.Blobs)) >= req.Size || readBytes >= maxMessageSize {
 			break
 		}
 	}
@@ -258,7 +258,7 @@ func (srv *SyncServer) handleGetBlobsByListRequest(ctx context.Context, stream n
 		sucRead++
 		res.Blobs = append(res.Blobs, payload)
 		readBytes += uint64(len(payload.EncodedBlob))
-		if readBytes >= req.Bytes || readBytes >= maxMessageSize {
+		if uint64(len(res.Blobs)) >= req.Size || readBytes >= maxMessageSize {
 			break
 		}
 	}

--- a/ethstorage/p2p/protocol/syncserver.go
+++ b/ethstorage/p2p/protocol/syncserver.go
@@ -191,7 +191,7 @@ func (srv *SyncServer) handleGetBlobsByRangeRequest(ctx context.Context, stream 
 		ShardId:  req.ShardId,
 		Blobs:    make([]*BlobPayload, 0),
 	}
-	read, sucRead, l := uint64(0), uint64(0), uint64(0)
+	read, sucRead, l, size := uint64(0), uint64(0), uint64(0), req.Bytes/srv.storageManager.MaxKvSize()
 	start := time.Now()
 	for id := req.Origin; id <= req.Limit; id++ {
 		payload, err := srv.BlobByIndex(id)
@@ -203,7 +203,7 @@ func (srv *SyncServer) handleGetBlobsByRangeRequest(ctx context.Context, stream 
 		sucRead++
 		res.Blobs = append(res.Blobs, payload)
 		l++
-		if l >= req.Size || l >= maxRequestSize {
+		if l >= size || l >= maxRequestSize {
 			break
 		}
 	}
@@ -246,7 +246,7 @@ func (srv *SyncServer) handleGetBlobsByListRequest(ctx context.Context, stream n
 		ShardId:  req.ShardId,
 		Blobs:    make([]*BlobPayload, 0),
 	}
-	read, sucRead, l := uint64(0), uint64(0), uint64(0)
+	read, sucRead, l, size := uint64(0), uint64(0), uint64(0), req.Bytes/srv.storageManager.MaxKvSize()
 	start := time.Now()
 	for _, idx := range req.BlobList {
 		payload, err := srv.BlobByIndex(idx)
@@ -258,7 +258,7 @@ func (srv *SyncServer) handleGetBlobsByListRequest(ctx context.Context, stream n
 		sucRead++
 		res.Blobs = append(res.Blobs, payload)
 		l++
-		if l >= req.Size || l >= maxRequestSize {
+		if l >= size || l >= maxRequestSize {
 			break
 		}
 	}

--- a/ethstorage/p2p/protocol/syncserver.go
+++ b/ethstorage/p2p/protocol/syncserver.go
@@ -42,7 +42,7 @@ const (
 	peerServerBlocksBurst = 10
 
 	// maxRequestSize is the target maximum size of replies to data retrievals.
-	maxRequestSize = 32
+	maxRequestSize = 64
 )
 
 var (

--- a/ethstorage/p2p/protocol/syncserver.go
+++ b/ethstorage/p2p/protocol/syncserver.go
@@ -192,8 +192,8 @@ func (srv *SyncServer) handleGetBlobsByRangeRequest(ctx context.Context, stream 
 		ShardId:  req.ShardId,
 		Blobs:    make([]*BlobPayload, 0),
 	}
-	bs := uint64(math.Min(maxRequestSize, float64(req.Bytes)))
-	read, sucRead, l, size := uint64(0), uint64(0), uint64(0), bs/srv.storageManager.MaxKvSize()
+	maxbytes := uint64(math.Min(maxRequestSize, float64(req.Bytes)))
+	read, sucRead, readBytes := uint64(0), uint64(0), uint64(0)
 	start := time.Now()
 	for id := req.Origin; id <= req.Limit; id++ {
 		payload, err := srv.BlobByIndex(id)
@@ -204,8 +204,8 @@ func (srv *SyncServer) handleGetBlobsByRangeRequest(ctx context.Context, stream 
 		}
 		sucRead++
 		res.Blobs = append(res.Blobs, payload)
-		l++
-		if l >= size {
+		readBytes += uint64(len(payload.EncodedBlob))
+		if readBytes >= maxbytes {
 			break
 		}
 	}
@@ -248,8 +248,8 @@ func (srv *SyncServer) handleGetBlobsByListRequest(ctx context.Context, stream n
 		ShardId:  req.ShardId,
 		Blobs:    make([]*BlobPayload, 0),
 	}
-	bs := uint64(math.Min(maxRequestSize, float64(req.Bytes)))
-	read, sucRead, l, size := uint64(0), uint64(0), uint64(0), bs/srv.storageManager.MaxKvSize()
+	maxbytes := uint64(math.Min(maxRequestSize, float64(req.Bytes)))
+	read, sucRead, readBytes := uint64(0), uint64(0), uint64(0)
 	start := time.Now()
 	for _, idx := range req.BlobList {
 		payload, err := srv.BlobByIndex(idx)
@@ -260,8 +260,8 @@ func (srv *SyncServer) handleGetBlobsByListRequest(ctx context.Context, stream n
 		}
 		sucRead++
 		res.Blobs = append(res.Blobs, payload)
-		l++
-		if l >= size {
+		readBytes += uint64(len(payload.EncodedBlob))
+		if readBytes >= maxbytes {
 			break
 		}
 	}

--- a/ethstorage/p2p/protocol/tracker.go
+++ b/ethstorage/p2p/protocol/tracker.go
@@ -81,7 +81,7 @@ func (t *Tracker) Capacity(targetRTT time.Duration) int {
 // roundCapacity gives the integer value of a capacity.
 // The result fits int32, and is guaranteed to be positive.
 func roundCapacity(cap float64) int {
-	return int(math.Min(maxRequestSize, math.Max(1, math.Ceil(cap))))
+	return int(math.Min(maxRequestSize, math.Max(128*1024, math.Ceil(cap))))
 }
 
 // Update modifies the peer's capacity values for a specific data type with a new

--- a/ethstorage/p2p/protocol/tracker.go
+++ b/ethstorage/p2p/protocol/tracker.go
@@ -66,12 +66,12 @@ func NewTracker(peerID string, cap float64) *Tracker {
 // the load proportionally to the requested items, so fetching a bit more might
 // still take the same RTT. By forcefully overshooting by a small amount, we can
 // avoid locking into a lower-that-real capacity.
-func (t *Tracker) Capacity(targetRTT time.Duration) int {
+func (t *Tracker) Capacity(targetRTT float64) int {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
 
 	// Calculate the actual measured throughput
-	throughput := t.capacity * float64(targetRTT) / float64(time.Second)
+	throughput := t.capacity * targetRTT
 
 	// Return an overestimation to force the peer out of a stuck minima, adding
 	// +1 in case the item count is too low for the overestimator to dent

--- a/ethstorage/p2p/protocol/tracker.go
+++ b/ethstorage/p2p/protocol/tracker.go
@@ -46,7 +46,7 @@ type Tracker struct {
 	// from disk, which is linear in the number of items, but mostly constant
 	// in their sizes.
 	peerID   string
-	capacity float64
+	capacity float64 // TODO backward compatible, change to blob count in the next testnet
 
 	lock sync.RWMutex
 }

--- a/ethstorage/p2p/protocol/tracker.go
+++ b/ethstorage/p2p/protocol/tracker.go
@@ -100,5 +100,5 @@ func (t *Tracker) Update(elapsed time.Duration, items int) {
 
 	oldcap := t.capacity
 	t.capacity = (1-measurementImpact)*(t.capacity) + measurementImpact*measured
-	log.Warn("Update tracker", "peer id", t.peerID, "elapsed", elapsed, "items", items, "old capacity", oldcap, "capacity", t.capacity)
+	log.Debug("Update tracker", "peer id", t.peerID, "elapsed", elapsed, "items", items, "old capacity", oldcap, "capacity", t.capacity)
 }

--- a/ethstorage/p2p/protocol/types.go
+++ b/ethstorage/p2p/protocol/types.go
@@ -136,7 +136,7 @@ type EthStorageSyncDone struct {
 
 type SyncerParams struct {
 	MaxPeers              int
-	MaxRequestSize        uint64
+	InitRequestSize       uint64
 	SyncConcurrency       uint64
 	FillEmptyConcurrency  int
 	MetaDownloadBatchSize uint64

--- a/ethstorage/p2p/protocol/types.go
+++ b/ethstorage/p2p/protocol/types.go
@@ -74,7 +74,7 @@ type GetBlobsByRangePacket struct {
 	ShardId  uint64         // ShardId
 	Origin   uint64         // Index of the first Blob to retrieve
 	Limit    uint64         // Index of the last Blob to retrieve
-	Bytes    uint64         // Soft limit at which to stop returning data
+	Size     uint64         // Soft limit at which to stop returning data
 }
 
 // BlobsByRangePacket represents a Blobs query response.
@@ -91,7 +91,7 @@ type GetBlobsByListPacket struct {
 	Contract common.Address // Contract of the sharded storage
 	ShardId  uint64         // ShardId
 	BlobList []uint64       // BlobList index list to retrieve
-	Bytes    uint64         // Soft limit at which to stop returning data
+	Size     uint64         // Soft limit at which to stop returning data
 }
 
 // BlobsByListPacket represents a Blobs query response.

--- a/ethstorage/p2p/protocol/types.go
+++ b/ethstorage/p2p/protocol/types.go
@@ -74,7 +74,7 @@ type GetBlobsByRangePacket struct {
 	ShardId  uint64         // ShardId
 	Origin   uint64         // Index of the first Blob to retrieve
 	Limit    uint64         // Index of the last Blob to retrieve
-	Size     uint64         // Soft limit at which to stop returning data
+	Bytes    uint64         // Soft limit at which to stop returning data
 }
 
 // BlobsByRangePacket represents a Blobs query response.
@@ -91,7 +91,7 @@ type GetBlobsByListPacket struct {
 	Contract common.Address // Contract of the sharded storage
 	ShardId  uint64         // ShardId
 	BlobList []uint64       // BlobList index list to retrieve
-	Size     uint64         // Soft limit at which to stop returning data
+	Bytes    uint64         // Soft limit at which to stop returning data
 }
 
 // BlobsByListPacket represents a Blobs query response.

--- a/ethstorage/p2p/protocol/utils.go
+++ b/ethstorage/p2p/protocol/utils.go
@@ -23,6 +23,9 @@ const (
 
 	// expect request time
 	expectRequestTime = time.Second * 8
+
+	// TODO backward compatible, can be remove before next testnet
+	blobSize = 128 * 1024
 )
 
 func WriteMsg(stream network.Stream, msg *Msg) error {

--- a/ethstorage/p2p/protocol/utils.go
+++ b/ethstorage/p2p/protocol/utils.go
@@ -18,7 +18,7 @@ import (
 const clientError = 255
 
 func WriteMsg(stream network.Stream, msg *Msg) error {
-	_ = stream.SetWriteDeadline(time.Now().Add(clientWriteRequestTimeout))
+	_ = stream.SetWriteDeadline(time.Now().Add(p2pReadWriteTimeout))
 	// write return code
 	n, err := stream.Write([]byte{msg.ReturnCode})
 	if err != nil {
@@ -49,7 +49,7 @@ func WriteMsg(stream network.Stream, msg *Msg) error {
 }
 
 func ReadMsg(stream network.Stream) ([]byte, byte, error) {
-	_ = stream.SetReadDeadline(time.Now().Add(clientReadResponsetimeout))
+	_ = stream.SetReadDeadline(time.Now().Add(p2pReadWriteTimeout))
 	var returnCode [1]byte
 	if _, err := io.ReadFull(stream, returnCode[:]); err != nil {
 		return nil, clientError, fmt.Errorf("failed to read result part of response: %w", err)

--- a/ethstorage/p2p/protocol/utils.go
+++ b/ethstorage/p2p/protocol/utils.go
@@ -23,9 +23,6 @@ const (
 
 	// expect request time
 	expectRequestTime = time.Second * 8
-
-	// TODO backward compatible, can be remove before next testnet
-	blobSize = 128 * 1024
 )
 
 func WriteMsg(stream network.Stream, msg *Msg) error {

--- a/ethstorage/p2p/protocol/utils.go
+++ b/ethstorage/p2p/protocol/utils.go
@@ -15,7 +15,15 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 )
 
-const clientError = 255
+const (
+	clientError = 255
+
+	// timeout for reading / writing the request / response through P2P.
+	p2pReadWriteTimeout = time.Second * 10
+
+	// expect request time
+	expectRequestTime = time.Second * 8
+)
 
 func WriteMsg(stream network.Stream, msg *Msg) error {
 	_ = stream.SetWriteDeadline(time.Now().Add(p2pReadWriteTimeout))

--- a/ethstorage/p2p/protocol/utils.go
+++ b/ethstorage/p2p/protocol/utils.go
@@ -21,8 +21,8 @@ const (
 	// timeout for reading / writing the request / response through P2P.
 	p2pReadWriteTimeout = time.Second * 10
 
-	// expect request time
-	expectRequestTime = time.Second * 8
+	// rttEstimateFactor is a multiplier used to estimate the maximum round-trip time to a target request using p2pReadWriteTimeout.
+	rttEstimateFactor = 0.8
 )
 
 func WriteMsg(stream network.Stream, msg *Msg) error {

--- a/run-rpc.sh
+++ b/run-rpc.sh
@@ -21,7 +21,7 @@ es_node_start=" --network devnet \
   --l1.beacon http://88.99.30.186:3500 \
   --l1.beacon-based-time 1706684472 \
   --l1.beacon-based-slot 4245906 \
-  --p2p.max.request.size 4194304 \
+  --p2p.request.size 4194304 \
   --p2p.listen.udp 30305 \
   --p2p.sync.concurrency 32 \
   --p2p.bootnodes enr:-Li4QFpDtIlnf02Bli8jnZEkVAFyWkOOtaUZL7yKp3ySKmhGNiqRSe4AuUcFip3F4o_YLh30HJUg2UlcmIxx5W-fsK2GAY1eoPcdimV0aHN0b3JhZ2XbAYDY15SATFINPAhMgF43o16QBXrDKDH5b8GAgmlkgnY0gmlwhEFtMpGJc2VjcDI1NmsxoQL0mXwUXANkLHIAjN23dPfnOOhu-jhFUN13jcjHWeIP04N0Y3CCJAaDdWRwgnZh \

--- a/run-rpc.sh
+++ b/run-rpc.sh
@@ -21,7 +21,6 @@ es_node_start=" --network devnet \
   --l1.beacon http://88.99.30.186:3500 \
   --l1.beacon-based-time 1706684472 \
   --l1.beacon-based-slot 4245906 \
-  --p2p.request.size 4194304 \
   --p2p.listen.udp 30305 \
   --p2p.sync.concurrency 32 \
   --p2p.bootnodes enr:-Li4QFpDtIlnf02Bli8jnZEkVAFyWkOOtaUZL7yKp3ySKmhGNiqRSe4AuUcFip3F4o_YLh30HJUg2UlcmIxx5W-fsK2GAY1eoPcdimV0aHN0b3JhZ2XbAYDY15SATFINPAhMgF43o16QBXrDKDH5b8GAgmlkgnY0gmlwhEFtMpGJc2VjcDI1NmsxoQL0mXwUXANkLHIAjN23dPfnOOhu-jhFUN13jcjHWeIP04N0Y3CCJAaDdWRwgnZh \

--- a/run.sh
+++ b/run.sh
@@ -125,7 +125,7 @@ es_node_start=" --network devnet \
   --download.thread 32 \
   --state.upload.url http://metrics.ethstorage.io:8080 \
   --p2p.listen.udp 30305 \
-  --p2p.max.request.size 4194304 \
+  --p2p.request.size 4194304 \
   --p2p.sync.concurrency 32 \
   --p2p.bootnodes enr:-Li4QF3vBkkDQYNLHlVjW5NcEpXAsfNtE1lUVb_LgUQ_Ot2afS8jbDfnYQBDABJud_5Hd1hX_1cNeGVU6Tem06WDlfaGAY1e3vNvimV0aHN0b3JhZ2XbAYDY15SATFINPAhMgF43o16QBXrDKDH5b8GAgmlkgnY0gmlwhEFtP5qJc2VjcDI1NmsxoQK8XODtSv0IsrhBxZmTZBZEoLssb7bTX0YOVl6S0yLxuYN0Y3CCJAaDdWRwgnZh \
 $@"

--- a/run.sh
+++ b/run.sh
@@ -125,7 +125,6 @@ es_node_start=" --network devnet \
   --download.thread 32 \
   --state.upload.url http://metrics.ethstorage.io:8080 \
   --p2p.listen.udp 30305 \
-  --p2p.request.size 4194304 \
   --p2p.sync.concurrency 32 \
   --p2p.bootnodes enr:-Li4QF3vBkkDQYNLHlVjW5NcEpXAsfNtE1lUVb_LgUQ_Ot2afS8jbDfnYQBDABJud_5Hd1hX_1cNeGVU6Tem06WDlfaGAY1e3vNvimV0aHN0b3JhZ2XbAYDY15SATFINPAhMgF43o16QBXrDKDH5b8GAgmlkgnY0gmlwhEFtP5qJc2VjcDI1NmsxoQK8XODtSv0IsrhBxZmTZBZEoLssb7bTX0YOVl6S0yLxuYN0Y3CCJAaDdWRwgnZh \
 $@"


### PR DESCRIPTION
Issue: https://github.com/ethstorage/es-node/issues/232

Currently, we use p2p.max.request.size to control the size of blobs fetched from peers. However, different peers are distributed in different regions, so the request sizes between the local node and peers should be different. So we should use different request sizes to fetch blobs from different peers.

1. Change the p2p.max.request.size to p2p.request.size which will be used to initialize the request size from a new peer.
2. Add a tracker for each peer to adjust request size according to network conditions between the peer and local node.
	capacity = 0.9*(t.capacity) + 0.1* return blobs/second (Return blob count/Return time in second)
3. When selecting an idle peer to send a new request, order idle peers by their capacities, and select the peer with the biggest capacity.


This design refers to rates design in "github.com\ethereum\go-ethereum\eth\protocols\snap\sync.go" as the following:
![1716396243340](https://github.com/ethstorage/es-node/assets/14110556/f7873abe-e517-4aa5-ba92-f294c6460a89)

A similar design also exists in prysm, it uses both capacity and score (processedBatches * 0.1) to sort, and also adds some randomness to select that peer or not.
![1716685393539](https://github.com/ethstorage/es-node/assets/14110556/bb99a778-4395-4de9-b657-baf6c921727d)
![1716685393555](https://github.com/ethstorage/es-node/assets/14110556/22777dfe-4fe5-440a-85fb-8f064c49afc9)
![1716685393570](https://github.com/ethstorage/es-node/assets/14110556/7fb25b21-5c68-419b-bee4-62727f838f20)
![1716691956365](https://github.com/ethstorage/es-node/assets/14110556/43cbdc5c-dceb-4e89-8604-26ea0ef3fa10)
![1716691956385](https://github.com/ethstorage/es-node/assets/14110556/485bdc6d-af45-4506-bb44-3397d92ef3a4)

**How To Test**
Change to the log level to debug, or change the following code in the tracker.go to info. Then run the es-node from the begining.
`log.Debug("Update tracker", "peer id", t.peerID, "elapsed", elapsed, "items", items, "old capacity", oldcap, "capacity", t.capacity)`

then check the log like the following:
`t=2024-05-25T11:46:19+0000 lvl=info msg="Update tracker"                         "peer id"=16Uiu2HAmGAyykt2njnJYTSU9KsiFutrQKZA1w8LhS45ERpqxfwFV elapsed=333.787809ms items=8,388,608 "old capacity"=39724207.481  capacity=38264942.629`

The following is the test result for this feature between local node and peer on AX101. The inital request size is 8M, and after 3 minutes, the request size stable between 4.5M ~ 5.2M
![80272674f2478a3e226cc65f3c41536](https://github.com/ethstorage/es-node/assets/14110556/d2f16210-6ba1-433b-9f40-a14df1aa40c1)


