### PR TITLE
fix issue 262: close peers that have no addresses in the host.peerstore due to expired ttl.

### DIFF
--- a/ethstorage/p2p/node.go
+++ b/ethstorage/p2p/node.go
@@ -197,7 +197,7 @@ func (n *NodeP2P) PurgeBadPeers() {
 	for {
 		select {
 		case <-ticker.C:
-			peers := n.Host().Network().Peers()
+			peers := n.syncCl.Peers()
 			for _, p := range peers {
 				addrs := n.host.Peerstore().Addrs(p)
 				if len(addrs) > 0 {

--- a/ethstorage/p2p/node.go
+++ b/ethstorage/p2p/node.go
@@ -191,6 +191,7 @@ func (n *NodeP2P) init(resourcesCtx context.Context, rollupCfg *rollup.EsConfig,
 	return nil
 }
 
+// PurgeBadPeers will close peers that have no addresses in the host.peerstore due to expired ttl.
 func (n *NodeP2P) PurgeBadPeers() {
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()

--- a/ethstorage/p2p/node.go
+++ b/ethstorage/p2p/node.go
@@ -182,6 +182,8 @@ func (n *NodeP2P) init(resourcesCtx context.Context, rollupCfg *rollup.EsConfig,
 		if m != nil {
 			go m.RecordBandwidth(resourcesCtx, bwc)
 		}
+
+		go n.syncCl.PurgeBadPeers(n.host.Network().ClosePeer)
 	}
 	return nil
 }

--- a/ethstorage/p2p/protocol/peer.go
+++ b/ethstorage/p2p/protocol/peer.go
@@ -21,6 +21,7 @@ type Peer struct {
 	direction   network.Direction
 	version     uint                        // Protocol version negotiated
 	shards      map[common.Address][]uint64 // shards of this node support
+	isBad       bool
 	resCtx      context.Context
 	resCancel   context.CancelFunc
 	logger      log.Logger // Contextual logger with the peer id injected
@@ -36,6 +37,7 @@ func NewPeer(version uint, chainId *big.Int, peerId peer.ID, newStream newStream
 		direction:   direction,
 		version:     version,
 		shards:      shards,
+		isBad:       false,
 		resCtx:      ctx,
 		resCancel:   cancel,
 		logger:      log.New("peer", peerId[:8]),

--- a/ethstorage/p2p/protocol/peer.go
+++ b/ethstorage/p2p/protocol/peer.go
@@ -85,7 +85,7 @@ func (p *Peer) RequestBlobsByRange(id uint64, contract common.Address, shardId u
 
 	stream, err := p.newStreamFn(ctx, p.id, GetProtocolID(RequestBlobsByRangeProtocolID, p.chainId))
 	if err != nil {
-		return clientError, err
+		return streamError, err
 	}
 	defer func() {
 		if stream != nil {
@@ -114,7 +114,7 @@ func (p *Peer) RequestBlobsByList(id uint64, contract common.Address, shardId ui
 
 	stream, err := p.newStreamFn(ctx, p.id, GetProtocolID(RequestBlobsByListProtocolID, p.chainId))
 	if err != nil {
-		return clientError, err
+		return streamError, err
 	}
 	defer func() {
 		if stream != nil {

--- a/ethstorage/p2p/protocol/peer.go
+++ b/ethstorage/p2p/protocol/peer.go
@@ -21,7 +21,6 @@ type Peer struct {
 	direction   network.Direction
 	version     uint                        // Protocol version negotiated
 	shards      map[common.Address][]uint64 // shards of this node support
-	isBad       bool
 	resCtx      context.Context
 	resCancel   context.CancelFunc
 	logger      log.Logger // Contextual logger with the peer id injected
@@ -37,7 +36,6 @@ func NewPeer(version uint, chainId *big.Int, peerId peer.ID, newStream newStream
 		direction:   direction,
 		version:     version,
 		shards:      shards,
-		isBad:       false,
 		resCtx:      ctx,
 		resCancel:   cancel,
 		logger:      log.New("peer", peerId[:8]),

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -1084,6 +1084,18 @@ func (s *SyncClient) FillFileWithEmptyBlob(start, limit uint64) (uint64, error) 
 	return next, err
 }
 
+func (s *SyncClient) Peers() []peer.ID {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	peers := make([]peer.ID, 0, len(s.peers))
+	for pr := range s.peers {
+		peers = append(peers, pr)
+	}
+
+	return peers
+}
+
 // onResult is exclusively called by the main loop, and has thus direct access to the request bookkeeping state.
 // This function verifies if the result is canonical, and either promotes the result or moves the result into quarantine.
 func (s *SyncClient) onResult(blobs []*BlobPayload) (uint64, uint64, []uint64, error) {

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -1279,6 +1279,7 @@ func (s *SyncClient) PurgeBadPeers(closePeerFunc func(peer.ID) error) {
 				if err != nil {
 					log.Info("Purge bad peer failed", "peer", p.String(), "error", err.Error())
 				}
+				log.Debug("Purge bad peer", "peer", p.String())
 			}
 		case <-s.resCtx.Done():
 			log.Info("P2P PurgeBadPeers stop")

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -731,7 +731,9 @@ func (s *SyncClient) assignBlobRangeTasks() {
 
 				if err != nil {
 					if e, ok := err.(*yamux.Error); ok && e.Timeout() {
-						log.Debug("Failed to request blobs", "peer", pr.id.String(), "err", err)
+						log.Debug("Request blobs timeout", "peer", pr.id.String(), "err", err)
+					} else if returnCode == streamError {
+						log.Debug("Failed to request blobs as newStream failed", "peer", pr.id.String(), "err", err)
 					} else {
 						log.Info("Failed to request blobs", "peer", pr.id.String(), "err", err)
 					}
@@ -818,7 +820,9 @@ func (s *SyncClient) assignBlobHealTasks() {
 
 			if err != nil {
 				if e, ok := err.(*yamux.Error); ok && e.Timeout() {
-					log.Debug("Failed to request blobs", "peer", pr.id.String(), "err", err)
+					log.Debug("Request blobs timeout", "peer", pr.id.String(), "err", err)
+				} else if returnCode == streamError {
+					log.Debug("Failed to request blobs as newStream failed", "peer", pr.id.String(), "err", err)
 				} else {
 					log.Info("Failed to request blobs", "peer", pr.id.String(), "err", err)
 				}

--- a/ethstorage/p2p/protocol/utils.go
+++ b/ethstorage/p2p/protocol/utils.go
@@ -15,7 +15,10 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 )
 
-const clientError = 255
+const (
+	streamError = 254
+	clientError = 255
+)
 
 func WriteMsg(stream network.Stream, msg *Msg) error {
 	_ = stream.SetWriteDeadline(time.Now().Add(clientWriteRequestTimeout))


### PR DESCRIPTION
issue 262: https://github.com/ethstorage/es-node/issues/262

**Root Cause**
When creating a newStream to send a request to a peer, if the connection does not exist, it will call the peer again. But if the address of that peer does not exist, this issue will be thrown.
The peer address does not exist because of time-to-live timeout, which is 24 hours correctly. time-to-live timeout means the peer not be added back to peerstore by discovery.
![1716739858495](https://github.com/ethstorage/es-node/assets/14110556/97f0d406-f0c0-4d05-ac21-41bef1b702f3)

pstore.AddAddrs(info.ID, info.Addrs, discoveredAddrTTL) // discoveredAddrTTL = time.Hour * 24
 
![1716738775391](https://github.com/ethstorage/es-node/assets/14110556/aebb6559-682d-4abd-bfd6-e27de7443fbc)
![1716738780004](https://github.com/ethstorage/es-node/assets/14110556/7488b19a-bb93-4f84-8589-68420910bb08)
![1716732239701](https://github.com/ethstorage/es-node/assets/14110556/26e5920f-9470-4c0a-ad4c-5d7fc5c397c3)
![1716732554046](https://github.com/ethstorage/es-node/assets/14110556/0e8f0b54-a49d-4cd9-8188-d2f90ad0851d)

**How to fix it**
Change the log level to debug for the error caused by newStream "no addresses" and close the peer.


