### PR TITLE
L2 support miner change

### DIFF
--- a/cmd/es-node/config.go
+++ b/cmd/es-node/config.go
@@ -88,6 +88,8 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		DataDir:        datadir,
 		StateUploadURL: ctx.GlobalString(flags.StateUploadURL.Name),
 		DBConfig:       db.DefaultDBConfig(),
+		// rpc url to get randao from
+		RandaoSourceURL: ctx.GlobalString(flags.RandaoURL.Name),
 		// 	Driver: *driverConfig,
 		RPC: node.RPCConfig{
 			ListenAddr: ctx.GlobalString(flags.RPCListenAddr.Name),

--- a/ethstorage/eth/polling_client.go
+++ b/ethstorage/eth/polling_client.go
@@ -87,7 +87,7 @@ func NewClient(
 		closedCh:   make(chan struct{}),
 	}
 	if qh == nil {
-		res.queryHeader = res.GetLatestHeader
+		res.queryHeader = res.getLatestHeader
 	} else {
 		res.queryHeader = qh
 	}
@@ -185,7 +185,7 @@ func (w *PollingClient) pollHeads() {
 	}
 }
 
-func (w *PollingClient) GetLatestHeader() (*types.Header, error) {
+func (w *PollingClient) getLatestHeader() (*types.Header, error) {
 	ctx, cancel := context.WithTimeout(w.ctx, 5*time.Second)
 	defer cancel()
 	latest, err := w.BlockNumber(ctx)

--- a/ethstorage/eth/polling_client.go
+++ b/ethstorage/eth/polling_client.go
@@ -186,7 +186,7 @@ func (w *PollingClient) pollHeads() {
 }
 
 func (w *PollingClient) GetLatestHeader() (*types.Header, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(w.ctx, 5*time.Second)
 	defer cancel()
 	latest, err := w.BlockNumber(ctx)
 	if err != nil {

--- a/ethstorage/eth/randao_client.go
+++ b/ethstorage/eth/randao_client.go
@@ -25,9 +25,7 @@ var l1BlockContract = common.HexToAddress("0x42000000000000000000000000000000000
 type RandaoClient struct {
 	*PollingClient
 	// rpc endpoint where randao is fetched from
-	rc      *ethclient.Client
-	rCtx    context.Context
-	rCancel context.CancelFunc
+	rc *ethclient.Client
 }
 
 func DialRandaoSource(ctx context.Context, randaoUrl, rawurl string, pollRate uint64, lgr log.Logger) (*RandaoClient, error) {
@@ -46,12 +44,9 @@ func DialRandaoSource(ctx context.Context, randaoUrl, rawurl string, pollRate ui
 
 // NewRandaoClient creates a client that uses the given RPC client.
 func NewRandaoClient(ctx context.Context, p *PollingClient, c *ethclient.Client) *RandaoClient {
-	cCtx, cancel := context.WithCancel(ctx)
 	res := &RandaoClient{
 		PollingClient: p,
 		rc:            c,
-		rCtx:          cCtx,
-		rCancel:       cancel,
 	}
 	return res
 }
@@ -63,7 +58,6 @@ func (w *RandaoClient) HeaderByNumber(ctx context.Context, blockNumber *big.Int)
 
 // Close closes the RandaoClient and the underlying RPC client it talks to.
 func (w *RandaoClient) Close() {
-	w.rCancel()
 	w.rc.Close()
 	w.PollingClient.Close()
 }

--- a/ethstorage/eth/randao_client.go
+++ b/ethstorage/eth/randao_client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 var l1BlockContract = common.HexToAddress("0x4200000000000000000000000000000000000015")
@@ -24,19 +25,23 @@ var l1BlockContract = common.HexToAddress("0x42000000000000000000000000000000000
 type RandaoClient struct {
 	*PollingClient
 	// rpc endpoint where randao is fetched from
-	rc        *ethclient.Client
-	rCtx      context.Context
-	rCancel   context.CancelFunc
-	rClosedCh chan struct{}
+	rc      *ethclient.Client
+	rCtx    context.Context
+	rCancel context.CancelFunc
 }
 
-func DialRandaoSource(randaoUrl string, p *PollingClient) (*RandaoClient, error) {
-	ctx := context.Background()
-	c, err := ethclient.DialContext(ctx, randaoUrl)
+func DialRandaoSource(ctx context.Context, randaoUrl, rawurl string, pollRate uint64, lgr log.Logger) (*RandaoClient, error) {
+	rc, err := ethclient.DialContext(ctx, randaoUrl)
 	if err != nil {
 		return nil, err
 	}
-	return NewRandaoClient(ctx, p, c), nil
+	cc, err := ethclient.DialContext(ctx, rawurl)
+	if err != nil {
+		return nil, err
+	}
+	bq := &RandaoBlockQuerier{rc, cc, lgr}
+	p := NewClient(ctx, cc, httpRegex.MatchString(rawurl), common.Address{}, pollRate, bq, lgr)
+	return NewRandaoClient(ctx, p, rc), nil
 }
 
 // NewRandaoClient creates a client that uses the given RPC client.
@@ -47,37 +52,49 @@ func NewRandaoClient(ctx context.Context, p *PollingClient, c *ethclient.Client)
 		rc:            c,
 		rCtx:          cCtx,
 		rCancel:       cancel,
-		rClosedCh:     make(chan struct{}),
 	}
 	return res
+}
+
+func (w *RandaoClient) HeaderByNumber(ctx context.Context, blockNumber *big.Int) (*types.Header, error) {
+	w.lgr.Debug("Fetching header by number by Randao client", "number", blockNumber)
+	return w.rc.HeaderByNumber(ctx, blockNumber)
 }
 
 // Close closes the RandaoClient and the underlying RPC client it talks to.
 func (w *RandaoClient) Close() {
 	w.rCancel()
-	<-w.rClosedCh
 	w.rc.Close()
+	w.PollingClient.Close()
 }
 
-func (w *RandaoClient) GetLatestNumber() (*big.Int, error) {
-	ctx, cancel := context.WithTimeout(w.ctx, 5*time.Second)
+type RandaoBlockQuerier struct {
+	// where randao is queried from
+	rc *ethclient.Client
+	// where contract is deployed
+	cc *ethclient.Client
+	l  log.Logger
+}
+
+func (q *RandaoBlockQuerier) GetLatestNumber() (*big.Int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	h := crypto.Keccak256Hash([]byte("number()"))
-	ret, err := w.CallContract(ctx, ethereum.CallMsg{
-		From: common.Address{},
+	ret, err := q.cc.CallContract(ctx, ethereum.CallMsg{
 		To:   &l1BlockContract,
 		Data: h[0:4],
 	}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call number() %v", err)
 	}
-	w.lgr.Info("DEBUG: GetLatestNumber from number()")
 	// The latest blockhash could be empty
 	curBlock := new(big.Int).Sub(new(big.Int).SetBytes(ret), common.Big1)
+	q.l.Debug("Got latest block number by Randao querier", "number", curBlock)
 	return curBlock, nil
 }
 
-func (w *RandaoClient) HeaderByNumber(ctx context.Context, blockNumber *big.Int) (*types.Header, error) {
-	return w.rc.HeaderByNumber(ctx, blockNumber)
+func (q *RandaoBlockQuerier) HeaderByNumber(ctx context.Context, blockNumber *big.Int) (*types.Header, error) {
+	q.l.Debug("Fetching header by number by Randao querier", "number", blockNumber)
+	return q.rc.HeaderByNumber(ctx, blockNumber)
 }

--- a/ethstorage/eth/randao_client.go
+++ b/ethstorage/eth/randao_client.go
@@ -1,0 +1,187 @@
+package eth
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type RandaoClient struct {
+	// rpc endpoint where randao is fetched from
+	c1 *ethclient.Client
+	// rpc endpoint where ethstorage contract is deployed
+	c2 *ethclient.Client
+
+	lgr             log.Logger
+	pollRate        time.Duration
+	ctx             context.Context
+	cancel          context.CancelFunc
+	currL1Number    *big.Int
+	l1BlockContract common.Address
+	subID           int
+
+	// pollReqCh is used to request new polls of the upstream
+	// RPC client.
+	pollReqCh chan struct{}
+
+	mtx sync.RWMutex
+
+	subs map[int]chan *types.Header
+
+	closedCh chan struct{}
+}
+
+// Dial connects a client to the given URL.
+func DialRandaoSource(randaoUrl string, c2 *ethclient.Client, lgr log.Logger) (*RandaoClient, error) {
+	ctx := context.Background()
+	c, err := ethclient.DialContext(ctx, randaoUrl)
+	if err != nil {
+		return nil, err
+	}
+	return NewRandaoClient(ctx, c, c2, lgr), nil
+}
+
+// NewRandaoClient creates a client that uses the given RPC client.
+func NewRandaoClient(ctx context.Context, c1, c2 *ethclient.Client, lgr log.Logger) *RandaoClient {
+	ctx, cancel := context.WithCancel(ctx)
+	res := &RandaoClient{
+		c1:              c1,
+		c2:              c2,
+		lgr:             lgr,
+		pollRate:        2 * time.Second, // TODO: @Qiang everytime devnet changed, we may need to change it
+		ctx:             ctx,
+		cancel:          cancel,
+		l1BlockContract: common.HexToAddress("0x4200000000000000000000000000000000000015"),
+		pollReqCh:       make(chan struct{}, 1),
+		subs:            make(map[int]chan *types.Header),
+		closedCh:        make(chan struct{}),
+	}
+	go res.pollHeads()
+	return res
+}
+
+// Close closes the RandaoClient and the underlying RPC client it talks to.
+func (w *RandaoClient) Close() {
+	w.cancel()
+	<-w.closedCh
+	w.c1.Close()
+}
+
+func (w *RandaoClient) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+	select {
+	case <-w.ctx.Done():
+		return nil, ErrSubscriberClosed
+	default:
+	}
+
+	sub := make(chan *types.Header, 1)
+	w.mtx.Lock()
+	subID := w.subID
+	w.subID++
+	w.subs[subID] = sub
+	w.mtx.Unlock()
+
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		for {
+			select {
+			case header := <-sub:
+				ch <- header
+			case <-quit:
+				w.mtx.Lock()
+				delete(w.subs, subID)
+				w.mtx.Unlock()
+				return nil
+			case <-w.ctx.Done():
+				return nil
+			}
+		}
+	}), nil
+}
+
+func (w *RandaoClient) pollHeads() {
+	// To prevent polls from stacking up in case HTTP requests
+	// are slow, use a similar model to the driver in which
+	// polls are requested manually after each header is fetched.
+	reqPollAfter := func() {
+		if w.pollRate == 0 {
+			return
+		}
+		time.AfterFunc(w.pollRate, w.reqPoll)
+	}
+
+	reqPollAfter()
+
+	defer close(w.closedCh)
+
+	for {
+		select {
+		case <-w.pollReqCh:
+			// We don't need backoff here because we'll just try again
+			// after the pollRate elapses.
+			num, err := w.getLatestNumber()
+			if err != nil {
+				w.lgr.Info("error getting latest l1 block number", "err", err)
+				reqPollAfter()
+				continue
+			}
+			if w.currL1Number != nil && w.currL1Number.Cmp(num) == 0 {
+				w.lgr.Trace("no change in l1 number, skipping notifications")
+				reqPollAfter()
+				continue
+			}
+
+			head, err := w.HeaderByNumber(w.ctx, num)
+			if err != nil {
+				w.lgr.Error("failed to get header by number", "err", err)
+				reqPollAfter()
+				continue
+			}
+			w.currL1Number = num
+
+			w.lgr.Trace("notifying subscribers of new number", "number", num)
+			w.mtx.RLock()
+			for _, sub := range w.subs {
+				sub <- head
+			}
+			w.mtx.RUnlock()
+			reqPollAfter()
+		case <-w.ctx.Done():
+			w.c1.Close()
+			return
+		}
+	}
+}
+
+func (w *RandaoClient) getLatestNumber() (*big.Int, error) {
+	ctx, cancel := context.WithTimeout(w.ctx, 5*time.Second)
+	defer cancel()
+
+	h := crypto.Keccak256Hash([]byte("number()"))
+	ret, err := w.c2.CallContract(ctx, ethereum.CallMsg{
+		From: common.Address{},
+		To:   &w.l1BlockContract,
+		Data: h[0:4],
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call number() %v", err)
+	}
+	return new(big.Int).SetBytes(ret), nil
+}
+
+func (w *RandaoClient) HeaderByNumber(ctx context.Context, blockNumber *big.Int) (*types.Header, error) {
+	return w.c1.HeaderByNumber(ctx, blockNumber)
+}
+
+func (w *RandaoClient) reqPoll() {
+	w.pollReqCh <- struct{}{}
+}

--- a/ethstorage/eth/randao_client.go
+++ b/ethstorage/eth/randao_client.go
@@ -1,10 +1,12 @@
+// Copyright 2022-2023, EthStorage.
+// For license information, see https://github.com/ethstorage/es-node/blob/main/LICENSE
+
 package eth
 
 import (
 	"context"
 	"fmt"
 	"math/big"
-	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
@@ -12,183 +14,70 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/log"
 )
 
+var l1BlockContract = common.HexToAddress("0x4200000000000000000000000000000000000015")
+
+// RandaoClient is a client that fetches the latest randao from the L1 block contract.
+// It uses the PollingClient to fetch the latest block number and then fetches the header
+// corresponding to that block number.
 type RandaoClient struct {
+	*PollingClient
 	// rpc endpoint where randao is fetched from
-	c1 *ethclient.Client
-	// rpc endpoint where ethstorage contract is deployed
-	c2 *ethclient.Client
-
-	lgr             log.Logger
-	pollRate        time.Duration
-	ctx             context.Context
-	cancel          context.CancelFunc
-	currL1Number    *big.Int
-	l1BlockContract common.Address
-	subID           int
-
-	// pollReqCh is used to request new polls of the upstream
-	// RPC client.
-	pollReqCh chan struct{}
-
-	mtx sync.RWMutex
-
-	subs map[int]chan *types.Header
-
-	closedCh chan struct{}
+	rc        *ethclient.Client
+	rCtx      context.Context
+	rCancel   context.CancelFunc
+	rClosedCh chan struct{}
 }
 
-// Dial connects a client to the given URL.
-func DialRandaoSource(randaoUrl string, c2 *ethclient.Client, lgr log.Logger) (*RandaoClient, error) {
+func DialRandaoSource(randaoUrl string, p *PollingClient) (*RandaoClient, error) {
 	ctx := context.Background()
 	c, err := ethclient.DialContext(ctx, randaoUrl)
 	if err != nil {
 		return nil, err
 	}
-	return NewRandaoClient(ctx, c, c2, lgr), nil
+	return NewRandaoClient(ctx, p, c), nil
 }
 
 // NewRandaoClient creates a client that uses the given RPC client.
-func NewRandaoClient(ctx context.Context, c1, c2 *ethclient.Client, lgr log.Logger) *RandaoClient {
-	ctx, cancel := context.WithCancel(ctx)
+func NewRandaoClient(ctx context.Context, p *PollingClient, c *ethclient.Client) *RandaoClient {
+	cCtx, cancel := context.WithCancel(ctx)
 	res := &RandaoClient{
-		c1:              c1,
-		c2:              c2,
-		lgr:             lgr,
-		pollRate:        2 * time.Second, // TODO: @Qiang everytime devnet changed, we may need to change it
-		ctx:             ctx,
-		cancel:          cancel,
-		l1BlockContract: common.HexToAddress("0x4200000000000000000000000000000000000015"),
-		pollReqCh:       make(chan struct{}, 1),
-		subs:            make(map[int]chan *types.Header),
-		closedCh:        make(chan struct{}),
+		PollingClient: p,
+		rc:            c,
+		rCtx:          cCtx,
+		rCancel:       cancel,
+		rClosedCh:     make(chan struct{}),
 	}
-	go res.pollHeads()
 	return res
 }
 
 // Close closes the RandaoClient and the underlying RPC client it talks to.
 func (w *RandaoClient) Close() {
-	w.cancel()
-	<-w.closedCh
-	w.c1.Close()
+	w.rCancel()
+	<-w.rClosedCh
+	w.rc.Close()
 }
 
-func (w *RandaoClient) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
-	select {
-	case <-w.ctx.Done():
-		return nil, ErrSubscriberClosed
-	default:
-	}
-
-	sub := make(chan *types.Header, 1)
-	w.mtx.Lock()
-	subID := w.subID
-	w.subID++
-	w.subs[subID] = sub
-	w.mtx.Unlock()
-
-	return event.NewSubscription(func(quit <-chan struct{}) error {
-		for {
-			select {
-			case header := <-sub:
-				ch <- header
-			case <-quit:
-				w.mtx.Lock()
-				delete(w.subs, subID)
-				w.mtx.Unlock()
-				return nil
-			case <-w.ctx.Done():
-				return nil
-			}
-		}
-	}), nil
-}
-
-func (w *RandaoClient) pollHeads() {
-	// To prevent polls from stacking up in case HTTP requests
-	// are slow, use a similar model to the driver in which
-	// polls are requested manually after each header is fetched.
-	reqPollAfter := func() {
-		if w.pollRate == 0 {
-			return
-		}
-		time.AfterFunc(w.pollRate, w.reqPoll)
-	}
-
-	reqPollAfter()
-
-	defer close(w.closedCh)
-
-	for {
-		select {
-		case <-w.pollReqCh:
-			// We don't need backoff here because we'll just try again
-			// after the pollRate elapses.
-			num, err := w.getLatestNumber()
-			if err != nil {
-				w.lgr.Info("error getting latest l1 block number", "err", err)
-				reqPollAfter()
-				continue
-			}
-			if w.currL1Number != nil && w.currL1Number.Cmp(num) == 0 {
-				w.lgr.Trace("no change in l1 number, skipping notifications")
-				reqPollAfter()
-				continue
-			}
-
-			head, err := w.HeaderByNumber(w.ctx, num)
-			if err != nil {
-				w.lgr.Error("failed to get header by number", "err", err)
-				reqPollAfter()
-				continue
-			}
-			w.currL1Number = num
-
-			w.lgr.Trace("notifying subscribers of new number", "number", num)
-			w.mtx.RLock()
-			for _, sub := range w.subs {
-				sub <- head
-			}
-			w.mtx.RUnlock()
-			reqPollAfter()
-		case <-w.ctx.Done():
-			w.c1.Close()
-			return
-		}
-	}
-}
-
-func (w *RandaoClient) getLatestNumber() (*big.Int, error) {
+func (w *RandaoClient) GetLatestNumber() (*big.Int, error) {
 	ctx, cancel := context.WithTimeout(w.ctx, 5*time.Second)
 	defer cancel()
 
 	h := crypto.Keccak256Hash([]byte("number()"))
-	ret, err := w.c2.CallContract(ctx, ethereum.CallMsg{
+	ret, err := w.CallContract(ctx, ethereum.CallMsg{
 		From: common.Address{},
-		To:   &w.l1BlockContract,
+		To:   &l1BlockContract,
 		Data: h[0:4],
 	}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call number() %v", err)
 	}
-	// L1Block contract cannot get latest blockhash
+	w.lgr.Info("DEBUG: GetLatestNumber from number()")
+	// The latest blockhash could be empty
 	curBlock := new(big.Int).Sub(new(big.Int).SetBytes(ret), common.Big1)
 	return curBlock, nil
 }
 
 func (w *RandaoClient) HeaderByNumber(ctx context.Context, blockNumber *big.Int) (*types.Header, error) {
-	header, err := w.c1.HeaderByNumber(ctx, blockNumber)
-	if err != nil {
-		return nil, err
-	}
-	w.lgr.Debug("fetching header by number", "number", blockNumber, "header", header)
-	return w.c1.HeaderByNumber(ctx, blockNumber)
-}
-
-func (w *RandaoClient) reqPoll() {
-	w.pollReqCh <- struct{}{}
+	return w.rc.HeaderByNumber(ctx, blockNumber)
 }

--- a/ethstorage/eth/randao_client.go
+++ b/ethstorage/eth/randao_client.go
@@ -181,6 +181,11 @@ func (w *RandaoClient) getLatestNumber() (*big.Int, error) {
 }
 
 func (w *RandaoClient) HeaderByNumber(ctx context.Context, blockNumber *big.Int) (*types.Header, error) {
+	header, err := w.c1.HeaderByNumber(ctx, blockNumber)
+	if err != nil {
+		return nil, err
+	}
+	w.lgr.Debug("fetching header by number", "number", blockNumber, "header", header)
 	return w.c1.HeaderByNumber(ctx, blockNumber)
 }
 

--- a/ethstorage/eth/randao_client.go
+++ b/ethstorage/eth/randao_client.go
@@ -23,6 +23,7 @@ var l1BlockContract = common.HexToAddress("0x42000000000000000000000000000000000
 // It uses the PollingClient to fetch the latest block number and then fetches the header
 // corresponding to that block number.
 type RandaoClient struct {
+	// inherits PollingClient to reuse SubscribeNewHead
 	*PollingClient
 	// rpc endpoint where randao is fetched from
 	rc *ethclient.Client

--- a/ethstorage/eth/randao_client.go
+++ b/ethstorage/eth/randao_client.go
@@ -175,7 +175,9 @@ func (w *RandaoClient) getLatestNumber() (*big.Int, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to call number() %v", err)
 	}
-	return new(big.Int).SetBytes(ret), nil
+	// L1Block contract cannot get latest blockhash
+	curBlock := new(big.Int).Sub(new(big.Int).SetBytes(ret), common.Big1)
+	return curBlock, nil
 }
 
 func (w *RandaoClient) HeaderByNumber(ctx context.Context, blockNumber *big.Int) (*types.Header, error) {

--- a/ethstorage/flags/flags.go
+++ b/ethstorage/flags/flags.go
@@ -57,6 +57,11 @@ var (
 		Usage:  "URL of the custom data availability service",
 		EnvVar: prefixEnvVar("DA_URL"),
 	}
+	RandaoURL = cli.StringFlag{
+		Name:   "randao.url",
+		Usage:  "URL of JSON-RPC endpoint to query randao",
+		EnvVar: prefixEnvVar("RANDAO_URL"),
+	}
 	// TODO: @Qiang everytime devnet changed, we may need to change it
 	L1BeaconBasedTime = cli.Uint64Flag{
 		Name:   "l1.beacon-based-time",
@@ -227,6 +232,7 @@ var optionalFlags = []cli.Flag{
 	L1BeaconBasedTime,
 	L1BeaconBasedSlot,
 	DAURL,
+	RandaoURL,
 	L1MinDurationForBlobsRequest,
 	L2ChainId,
 	MetricsEnabledFlag,

--- a/ethstorage/miner/l1_mining_api.go
+++ b/ethstorage/miner/l1_mining_api.go
@@ -29,12 +29,13 @@ var (
 	mineSig = crypto.Keccak256Hash([]byte(`mine(uint256,uint256,address,uint256,bytes32[],uint256[],bytes,bytes[],bytes[])`))
 )
 
-func NewL1MiningAPI(l1 *eth.PollingClient, lg log.Logger) *l1MiningAPI {
-	return &l1MiningAPI{l1, lg}
+func NewL1MiningAPI(l1 *eth.PollingClient, rc *eth.RandaoClient, lg log.Logger) *l1MiningAPI {
+	return &l1MiningAPI{l1, rc, lg}
 }
 
 type l1MiningAPI struct {
 	*eth.PollingClient
+	rc *eth.RandaoClient
 	lg log.Logger
 }
 
@@ -85,14 +86,9 @@ func (m *l1MiningAPI) GetDataHashes(ctx context.Context, contract common.Address
 
 func (m *l1MiningAPI) SubmitMinedResult(ctx context.Context, contract common.Address, rst result, cfg Config) (common.Hash, error) {
 	m.lg.Debug("Submit mined result", "shard", rst.startShardId, "block", rst.blockNumber, "nonce", rst.nonce)
-	blockHeader, err := m.HeaderByNumber(ctx, rst.blockNumber)
+	headerRlp, err := m.getRandaoProof(ctx, rst.blockNumber)
 	if err != nil {
-		m.lg.Error("Failed to get block header", "error", err)
-		return common.Hash{}, err
-	}
-	headerRlp, err := rlp.EncodeToBytes(blockHeader)
-	if err != nil {
-		m.lg.Error("Failed to encode block header", "error", err)
+		m.lg.Error("Failed to get randao proof", "error", err)
 		return common.Hash{}, err
 	}
 	uint256Type, _ := abi.NewType("uint256", "", nil)
@@ -209,6 +205,32 @@ func (m *l1MiningAPI) SubmitMinedResult(ctx context.Context, contract common.Add
 	m.lg.Info("Submit mined result done", "shard", rst.startShardId, "block", rst.blockNumber,
 		"nonce", rst.nonce, "txSigner", cfg.SignerAddr.Hex(), "hash", signedTx.Hash().Hex())
 	return signedTx.Hash(), nil
+}
+
+func (m *l1MiningAPI) getRandaoProof(ctx context.Context, blockNumber *big.Int) ([]byte, error) {
+	var (
+		caller interface {
+			HeaderByNumber(context.Context, *big.Int) (*types.Header, error)
+		}
+		blockHeader *types.Header
+		err         error
+	)
+	if m.rc != nil {
+		caller = m.rc
+	} else {
+		caller = m
+	}
+	blockHeader, err = caller.HeaderByNumber(ctx, blockNumber)
+	if err != nil {
+		m.lg.Error("Failed to get block header", "error", err)
+		return nil, err
+	}
+	headerRlp, err := rlp.EncodeToBytes(blockHeader)
+	if err != nil {
+		m.lg.Error("Failed to encode block header", "error", err)
+		return nil, err
+	}
+	return headerRlp, nil
 }
 
 // TODO: implement `miningReward()` in the contract to replace this impl

--- a/ethstorage/miner/l1_mining_api.go
+++ b/ethstorage/miner/l1_mining_api.go
@@ -85,12 +85,13 @@ func (m *l1MiningAPI) GetDataHashes(ctx context.Context, contract common.Address
 }
 
 func (m *l1MiningAPI) SubmitMinedResult(ctx context.Context, contract common.Address, rst result, cfg Config) (common.Hash, error) {
-	m.lg.Debug("Submit mined result", "shard", rst.startShardId, "block", rst.blockNumber, "nonce", rst.nonce)
+	m.lg.Debug("Submit mined result", "shard", rst.startShardId, "block", rst.blockNumber, "result", rst)
 	headerRlp, err := m.getRandaoProof(ctx, rst.blockNumber)
 	if err != nil {
 		m.lg.Error("Failed to get randao proof", "error", err)
 		return common.Hash{}, err
 	}
+	m.lg.Debug("Submit mined result", "headerRlp", common.Bytes2Hex(headerRlp))
 	uint256Type, _ := abi.NewType("uint256", "", nil)
 	uint256Array, _ := abi.NewType("uint256[]", "", nil)
 	addrType, _ := abi.NewType("address", "", nil)
@@ -119,7 +120,7 @@ func (m *l1MiningAPI) SubmitMinedResult(ctx context.Context, contract common.Add
 		rst.decodeProof,
 	)
 	calldata := append(mineSig[0:4], dataField...)
-
+	m.lg.Debug("Submit mined result", "calldata", common.Bytes2Hex(calldata))
 	gasPrice := cfg.GasPrice
 	if gasPrice == nil || gasPrice.Cmp(common.Big0) == 0 {
 		suggested, err := m.SuggestGasPrice(ctx)

--- a/ethstorage/miner/l1_mining_api.go
+++ b/ethstorage/miner/l1_mining_api.go
@@ -223,7 +223,7 @@ func (m *l1MiningAPI) getRandaoProof(ctx context.Context, blockNumber *big.Int) 
 	}
 	blockHeader, err = caller.HeaderByNumber(ctx, blockNumber)
 	if err != nil {
-		m.lg.Error("Failed to get block header", "error", err)
+		m.lg.Error("Failed to get block header", "number", blockNumber, "error", err)
 		return nil, err
 	}
 	headerRlp, err := rlp.EncodeToBytes(blockHeader)

--- a/ethstorage/miner/l1_mining_api.go
+++ b/ethstorage/miner/l1_mining_api.go
@@ -208,26 +208,22 @@ func (m *l1MiningAPI) SubmitMinedResult(ctx context.Context, contract common.Add
 }
 
 func (m *l1MiningAPI) getRandaoProof(ctx context.Context, blockNumber *big.Int) ([]byte, error) {
-	var (
-		caller interface {
-			HeaderByNumber(context.Context, *big.Int) (*types.Header, error)
-		}
-		blockHeader *types.Header
-		err         error
-	)
+	var caller interface {
+		HeaderByNumber(context.Context, *big.Int) (*types.Header, error)
+	}
 	if m.rc != nil {
 		caller = m.rc
 	} else {
 		caller = m.Client
 	}
-	blockHeader, err = caller.HeaderByNumber(ctx, blockNumber)
+	blockHeader, err := caller.HeaderByNumber(ctx, blockNumber)
 	if err != nil {
 		m.lg.Error("Failed to get block header", "number", blockNumber, "error", err)
 		return nil, err
 	}
 	headerRlp, err := rlp.EncodeToBytes(blockHeader)
 	if err != nil {
-		m.lg.Error("Failed to encode block header", "error", err)
+		m.lg.Error("Failed to encode block header in RLP", "error", err)
 		return nil, err
 	}
 	return headerRlp, nil

--- a/ethstorage/miner/l1_mining_api.go
+++ b/ethstorage/miner/l1_mining_api.go
@@ -218,7 +218,7 @@ func (m *l1MiningAPI) getRandaoProof(ctx context.Context, blockNumber *big.Int) 
 	if m.rc != nil {
 		caller = m.rc
 	} else {
-		caller = m
+		caller = m.Client
 	}
 	blockHeader, err = caller.HeaderByNumber(ctx, blockNumber)
 	if err != nil {

--- a/ethstorage/miner/l1_mining_api.go
+++ b/ethstorage/miner/l1_mining_api.go
@@ -85,13 +85,12 @@ func (m *l1MiningAPI) GetDataHashes(ctx context.Context, contract common.Address
 }
 
 func (m *l1MiningAPI) SubmitMinedResult(ctx context.Context, contract common.Address, rst result, cfg Config) (common.Hash, error) {
-	m.lg.Debug("Submit mined result", "shard", rst.startShardId, "block", rst.blockNumber, "result", rst)
+	m.lg.Debug("Submit mined result", "shard", rst.startShardId, "block", rst.blockNumber, "nonce", rst.nonce)
 	headerRlp, err := m.getRandaoProof(ctx, rst.blockNumber)
 	if err != nil {
 		m.lg.Error("Failed to get randao proof", "error", err)
 		return common.Hash{}, err
 	}
-	m.lg.Debug("Submit mined result", "headerRlp", common.Bytes2Hex(headerRlp))
 	uint256Type, _ := abi.NewType("uint256", "", nil)
 	uint256Array, _ := abi.NewType("uint256[]", "", nil)
 	addrType, _ := abi.NewType("address", "", nil)

--- a/ethstorage/miner/miner_test.go
+++ b/ethstorage/miner/miner_test.go
@@ -64,7 +64,7 @@ func newMiner(t *testing.T, storageMgr *es.StorageManager, client *eth.PollingCl
 		ZKProverMode:     2,
 		ZKeyFileName:     "blob_poseidon2.zkey",
 	}
-	l1api := NewL1MiningAPI(client, lg)
+	l1api := NewL1MiningAPI(client, nil, lg)
 	zkWorkingDir, _ := filepath.Abs("../prover")
 	pvr := prover.NewKZGPoseidonProver(zkWorkingDir, defaultConfig.ZKeyFileName, defaultConfig.ZKProverMode, lg)
 	fd := new(event.Feed)

--- a/ethstorage/miner/worker.go
+++ b/ethstorage/miner/worker.go
@@ -94,6 +94,11 @@ type result struct {
 	decodeProof     [][]byte
 }
 
+func (r *result) String() string {
+	return fmt.Sprintf("block: %v, startShardId: %d, miner: %x, nonce: %d, encodedData: %x, masks: %v, inclusiveProofs: %x, decodeProof: %x",
+		r.blockNumber, r.startShardId, r.miner.Hex(), r.nonce, r.encodedData, r.masks, r.inclusiveProofs, r.decodeProof)
+}
+
 // worker is the main object which takes care of storage mining
 // and submit the mining result tx to the L1 chain.
 type worker struct {

--- a/ethstorage/miner/worker.go
+++ b/ethstorage/miner/worker.go
@@ -381,7 +381,6 @@ func (w *worker) notifyResultLoop() {
 // resultLoop is a standalone goroutine to submit mining result to L1 contract.
 func (w *worker) resultLoop() {
 	defer w.wg.Done()
-	var startTime = time.Now().Format("2006-01-02 15:04:05")
 	errorCache := make([]miningError, 0)
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
@@ -442,10 +441,10 @@ func (w *worker) resultLoop() {
 			w.notifyResultLoop()
 		case <-ticker.C:
 			for shardId, s := range w.submissionStates {
-				log.Info(fmt.Sprintf("Mining stats since %s", startTime), "shard", shardId, "succeeded", s.Succeeded, "failed", s.Failed, "dropped", s.Dropped)
+				log.Info("Mining stats", "shard", shardId, "succeeded", s.Succeeded, "failed", s.Failed, "dropped", s.Dropped)
 			}
 			if len(errorCache) > 0 {
-				log.Error(fmt.Sprintf("Mining stats since %s", startTime), "lastError", errorCache[len(errorCache)-1])
+				log.Error("Mining stats", "lastError", errorCache[len(errorCache)-1])
 			}
 		case <-saveStatesTicker.C:
 			w.saveStates()

--- a/ethstorage/miner/worker.go
+++ b/ethstorage/miner/worker.go
@@ -94,11 +94,6 @@ type result struct {
 	decodeProof     [][]byte
 }
 
-func (r *result) String() string {
-	return fmt.Sprintf("block: %v, startShardId: %d, miner: %x, nonce: %d, encodedData: %x, masks: %v, inclusiveProofs: %x, decodeProof: %x",
-		r.blockNumber, r.startShardId, r.miner, r.nonce, r.encodedData, r.masks, r.inclusiveProofs, r.decodeProof)
-}
-
 // worker is the main object which takes care of storage mining
 // and submit the mining result tx to the L1 chain.
 type worker struct {

--- a/ethstorage/miner/worker.go
+++ b/ethstorage/miner/worker.go
@@ -96,7 +96,7 @@ type result struct {
 
 func (r *result) String() string {
 	return fmt.Sprintf("block: %v, startShardId: %d, miner: %x, nonce: %d, encodedData: %x, masks: %v, inclusiveProofs: %x, decodeProof: %x",
-		r.blockNumber, r.startShardId, r.miner.Hex(), r.nonce, r.encodedData, r.masks, r.inclusiveProofs, r.decodeProof)
+		r.blockNumber, r.startShardId, r.miner, r.nonce, r.encodedData, r.masks, r.inclusiveProofs, r.decodeProof)
 }
 
 // worker is the main object which takes care of storage mining

--- a/ethstorage/node/config.go
+++ b/ethstorage/node/config.go
@@ -24,6 +24,8 @@ import (
 type Config struct {
 	L1         eth.L1EndpointConfig
 	Downloader downloader.Config
+	// RPC used to query randao from a layer 1 blockchain when the storage contract is deployed on a layer 2
+	RandaoSourceURL string
 	// L2     L2EndpointSetup
 	// L2Sync L2SyncEndpointSetup
 

--- a/ethstorage/node/node.go
+++ b/ethstorage/node/node.go
@@ -164,7 +164,7 @@ func (n *EsNode) initL1(ctx context.Context, cfg *Config) error {
 		return fmt.Errorf("no L1 beacon or DA URL provided")
 	}
 	if cfg.RandaoSourceURL != "" {
-		rc, err := eth.DialRandaoSource(cfg.RandaoSourceURL, client)
+		rc, err := eth.DialRandaoSource(ctx, cfg.RandaoSourceURL, cfg.L1.L1NodeAddr, cfg.L1.L1BlockTime, n.log)
 		if err != nil {
 			return fmt.Errorf("failed to create randao source: %w", err)
 		}

--- a/ethstorage/node/node.go
+++ b/ethstorage/node/node.go
@@ -196,8 +196,9 @@ func (n *EsNode) startL1(cfg *Config) {
 		}
 		if n.randaoSource != nil {
 			return eth.WatchHeadChanges(n.resourcesCtx, n.randaoSource, n.OnNewRandaoSourceHead)
+		} else {
+			return eth.WatchHeadChanges(n.resourcesCtx, n.l1Source, n.OnNewRandaoSourceHead)
 		}
-		return eth.WatchHeadChanges(n.resourcesCtx, n.l1Source, n.OnNewRandaoSourceHead)
 	})
 	go func() {
 		err, ok := <-n.randaoHeadsSub.Err()

--- a/ethstorage/node/node.go
+++ b/ethstorage/node/node.go
@@ -164,7 +164,7 @@ func (n *EsNode) initL1(ctx context.Context, cfg *Config) error {
 		return fmt.Errorf("no L1 beacon or DA URL provided")
 	}
 	if cfg.RandaoSourceURL != "" {
-		rc, err := eth.DialRandaoSource(cfg.RandaoSourceURL, client.Client, n.log)
+		rc, err := eth.DialRandaoSource(cfg.RandaoSourceURL, client)
 		if err != nil {
 			return fmt.Errorf("failed to create randao source: %w", err)
 		}

--- a/integration_tests/node_mine_test.go
+++ b/integration_tests/node_mine_test.go
@@ -74,7 +74,7 @@ func TestMining(t *testing.T) {
 	resourcesCtx, close := context.WithCancel(context.Background())
 	feed := new(event.Feed)
 
-	l1api := miner.NewL1MiningAPI(pClient, lg)
+	l1api := miner.NewL1MiningAPI(pClient, nil, lg)
 	pvr := prover.NewKZGPoseidonProver(miningConfig.ZKWorkingDir, miningConfig.ZKeyFileName, 2, lg)
 	db := rawdb.NewMemoryDatabase()
 	mnr := miner.New(miningConfig, db, storageManager, l1api, &pvr, feed, lg)

--- a/run-l2.sh
+++ b/run-l2.sh
@@ -125,6 +125,7 @@ es_node_start=" --network devnet \
   --download.thread 32 \
   --p2p.listen.udp 30305 \
   --p2p.sync.concurrency 32 \
+  --p2p.bootnodes enr:-Li4QGUAA21O-0pgqnGoBLwvvminrlDjfxhqL6DvXhfOtvNdK871LELAT1Nn-NAa3hUi0Wmb-VIj1qi6fnbyA9yp5RGGAZALHvLnimV0aHN0b3JhZ2XbAYDY15SQpwjA3KCBykiphRqKMmd1FV-H_cGAgmlkgnY0gmlwhEFtMpGJc2VjcDI1NmsxoQJ8_OUONb_H7RMF6kXzZWDut2xriJ5JeKnH2cnb8en0e4N0Y3CCJAaDdWRwgnZh \
 $@"
   
 # create data file for shard 0 if not yet

--- a/run-l2.sh
+++ b/run-l2.sh
@@ -104,8 +104,8 @@ data_dir="./es-data"
 storage_file_0="$data_dir/shard-0.dat"
 
 common_flags=" --datadir $data_dir \
-  --l1.rpc http://88.99.30.186:8545 \
-  --storage.l1contract 0x804C520d3c084C805E37A35E90057Ac32831F96f \
+  --l1.rpc http://142.132.154.16:8545 \
+  --storage.l1contract 0x90a708C0dca081ca48a9851a8A326775155f87Fd \
   --storage.miner $ES_NODE_STORAGE_MINER \
   "
 
@@ -119,14 +119,9 @@ es_node_start=" --network devnet \
   --miner.zkey $zkey_name \
   --storage.files $storage_file_0 \
   --signer.private-key $ES_NODE_SIGNER_PRIVATE_KEY \
-  --l1.beacon http://88.99.30.186:3500 \
-  --l1.beacon-based-time 1706684472 \
-  --l1.beacon-based-slot 4245906 \
-  --download.thread 32 \
-  --state.upload.url http://metrics.ethstorage.io:8080 \
-  --p2p.listen.udp 30305 \
-  --p2p.sync.concurrency 32 \
-  --p2p.bootnodes enr:-Li4QF3vBkkDQYNLHlVjW5NcEpXAsfNtE1lUVb_LgUQ_Ot2afS8jbDfnYQBDABJud_5Hd1hX_1cNeGVU6Tem06WDlfaGAY1e3vNvimV0aHN0b3JhZ2XbAYDY15SATFINPAhMgF43o16QBXrDKDH5b8GAgmlkgnY0gmlwhEFtP5qJc2VjcDI1NmsxoQK8XODtSv0IsrhBxZmTZBZEoLssb7bTX0YOVl6S0yLxuYN0Y3CCJAaDdWRwgnZh \
+  --da.url http://142.132.154.16:8888 \
+  --randao.url http://88.99.30.186:8545 \
+  --l1.block_time 2 \
 $@"
   
 # create data file for shard 0 if not yet

--- a/run-l2.sh
+++ b/run-l2.sh
@@ -122,6 +122,9 @@ es_node_start=" --network devnet \
   --da.url http://142.132.154.16:8888 \
   --randao.url http://88.99.30.186:8545 \
   --l1.block_time 2 \
+  --download.thread 32 \
+  --p2p.listen.udp 30305 \
+  --p2p.sync.concurrency 32 \
 $@"
   
 # create data file for shard 0 if not yet

--- a/run.sh
+++ b/run.sh
@@ -104,8 +104,8 @@ data_dir="./es-data"
 storage_file_0="$data_dir/shard-0.dat"
 
 common_flags=" --datadir $data_dir \
-  --l1.rpc http://88.99.30.186:8545 \
-  --storage.l1contract 0x804C520d3c084C805E37A35E90057Ac32831F96f \
+  --l1.rpc http://142.132.154.16:8545 \
+  --storage.l1contract 0x90a708C0dca081ca48a9851a8A326775155f87Fd \
   --storage.miner $ES_NODE_STORAGE_MINER \
   "
 
@@ -119,14 +119,9 @@ es_node_start=" --network devnet \
   --miner.zkey $zkey_name \
   --storage.files $storage_file_0 \
   --signer.private-key $ES_NODE_SIGNER_PRIVATE_KEY \
-  --l1.beacon http://88.99.30.186:3500 \
-  --l1.beacon-based-time 1706684472 \
-  --l1.beacon-based-slot 4245906 \
-  --download.thread 32 \
-  --state.upload.url http://metrics.ethstorage.io:8080 \
-  --p2p.listen.udp 30305 \
+  --da.url http://142.132.154.16:8888 \
   --p2p.sync.concurrency 32 \
-  --p2p.bootnodes enr:-Li4QF3vBkkDQYNLHlVjW5NcEpXAsfNtE1lUVb_LgUQ_Ot2afS8jbDfnYQBDABJud_5Hd1hX_1cNeGVU6Tem06WDlfaGAY1e3vNvimV0aHN0b3JhZ2XbAYDY15SATFINPAhMgF43o16QBXrDKDH5b8GAgmlkgnY0gmlwhEFtP5qJc2VjcDI1NmsxoQK8XODtSv0IsrhBxZmTZBZEoLssb7bTX0YOVl6S0yLxuYN0Y3CCJAaDdWRwgnZh \
+  --randao.url http://88.99.30.186:8545 \
 $@"
   
 # create data file for shard 0 if not yet


### PR DESCRIPTION
For the miner to read Randao from L1 blocks, add a polling client to sync the latest L1 block number known by the L2 by calling `L1Block` contract.
 