### PR TITLE
add `concurrency` to release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
     tags: 
       - 'v*'
 
+# Always wait for previous release to finish before releasing again
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Copied from [here](https://github.com/ethereum-optimism/optimism/blob/develop/.github/workflows/release.yml#L9), it seems good practice to follow.