### PR TITLE
The RPC service needs to be public when running the RPC script.

### DIFF
--- a/run-l2-rpc.sh
+++ b/run-l2-rpc.sh
@@ -21,6 +21,7 @@ es_node_start=" --network devnet \
   --da.url http://142.132.154.16:8888 \
   --l1.block_time 2 \
   --download.thread 32 \
+  --rpc.addr 0.0.0.0 \
   --p2p.listen.udp 30305 \
   --p2p.sync.concurrency 32 \
   --p2p.bootnodes enr:-Li4QGUAA21O-0pgqnGoBLwvvminrlDjfxhqL6DvXhfOtvNdK871LELAT1Nn-NAa3hUi0Wmb-VIj1qi6fnbyA9yp5RGGAZALHvLnimV0aHN0b3JhZ2XbAYDY15SQpwjA3KCBykiphRqKMmd1FV-H_cGAgmlkgnY0gmlwhEFtMpGJc2VjcDI1NmsxoQJ8_OUONb_H7RMF6kXzZWDut2xriJ5JeKnH2cnb8en0e4N0Y3CCJAaDdWRwgnZh \

--- a/run-rpc.sh
+++ b/run-rpc.sh
@@ -21,6 +21,7 @@ es_node_start=" --network devnet \
   --l1.beacon http://88.99.30.186:3500 \
   --l1.beacon-based-time 1706684472 \
   --l1.beacon-based-slot 4245906 \
+  --rpc.addr 0.0.0.0 \
   --p2p.listen.udp 30305 \
   --p2p.sync.concurrency 32 \
   --p2p.bootnodes enr:-Li4QFpDtIlnf02Bli8jnZEkVAFyWkOOtaUZL7yKp3ySKmhGNiqRSe4AuUcFip3F4o_YLh30HJUg2UlcmIxx5W-fsK2GAY1eoPcdimV0aHN0b3JhZ2XbAYDY15SATFINPAhMgF43o16QBXrDKDH5b8GAgmlkgnY0gmlwhEFtMpGJc2VjcDI1NmsxoQL0mXwUXANkLHIAjN23dPfnOOhu-jhFUN13jcjHWeIP04N0Y3CCJAaDdWRwgnZh \


### PR DESCRIPTION
The default value of `rpc.addr` is 127.0.0.1, which can’t serve external requests. It needs to be set to 0.0.0.0.