### PR TITLE
Batch download into cache

### DIFF
--- a/ethstorage/downloader/downloader.go
+++ b/ethstorage/downloader/downloader.go
@@ -227,13 +227,13 @@ func (s *Downloader) downloadToCache() {
 		}
 		_, err := s.downloadRange(start+1, rangeEnd, true)
 
-		if err == nil {
-			s.lastCacheBlock = rangeEnd
-			start = rangeEnd
-		} else {
+		if err != nil {
 			s.log.Error("DownloadRange failed", "err", err)
 			return
 		}
+
+		s.lastCacheBlock = rangeEnd
+		start = rangeEnd
 	}
 }
 

--- a/ethstorage/downloader/downloader.go
+++ b/ethstorage/downloader/downloader.go
@@ -220,14 +220,20 @@ func (s *Downloader) downloadToCache() {
 	}
 	s.mu.Unlock()
 
-	// @Qiang devnet-4 have issues to get blob event for the latest block, so if we need roll back to devnet-4
-	// we may need to change it to s.downloadRange(start, end, true)
-	_, err := s.downloadRange(start+1, end, true)
+	for start < end {
+		rangeEnd := start + downloadBatchSize
+		if rangeEnd > end {
+			rangeEnd = end
+		}
+		_, err := s.downloadRange(start+1, rangeEnd, true)
 
-	if err == nil {
-		s.lastCacheBlock = end
-	} else {
-		s.log.Info("DownloadRange failed", "err", err)
+		if err == nil {
+			s.lastCacheBlock = rangeEnd
+			start = rangeEnd
+		} else {
+			s.log.Error("DownloadRange failed", "err", err)
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
The very long finalization time on L2 (12 hours) breaks our initial assumption about `downloadToCache`. Therefore, we may need to batch download the BLOB to cache in case there are too many events emitted from the storage contract and the es-node can’t handle them all at once.
