### PR TITLE
Encode blobs while downloading

### DIFF
--- a/ethstorage/downloader/blob_cache.go
+++ b/ethstorage/downloader/blob_cache.go
@@ -12,24 +12,24 @@ import (
 	"github.com/ethstorage/go-ethstorage/ethstorage"
 )
 
-type BlobCache struct {
+type BlobMemCache struct {
 	blocks map[common.Hash]*blockBlobs
 	mu     sync.RWMutex
 }
 
-func NewBlobCache() *BlobCache {
-	return &BlobCache{
+func NewBlobMemCache() *BlobMemCache {
+	return &BlobMemCache{
 		blocks: map[common.Hash]*blockBlobs{},
 	}
 }
 
-func (c *BlobCache) SetBlockBlobs(block *blockBlobs) {
+func (c *BlobMemCache) SetBlockBlobs(block *blockBlobs) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.blocks[block.hash] = block
 }
 
-func (c *BlobCache) Blobs(hash common.Hash) []blob {
+func (c *BlobMemCache) Blobs(hash common.Hash) []blob {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -44,7 +44,7 @@ func (c *BlobCache) Blobs(hash common.Hash) []blob {
 	return res
 }
 
-func (c *BlobCache) GetKeyValueByIndex(idx uint64, hash common.Hash) []byte {
+func (c *BlobMemCache) GetKeyValueByIndex(idx uint64, hash common.Hash) []byte {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -61,7 +61,7 @@ func (c *BlobCache) GetKeyValueByIndex(idx uint64, hash common.Hash) []byte {
 // TODO: @Qiang An edge case that may need to be handled when Ethereum block is NOT finalized for a long time
 // We may need to add a counter in SetBlockBlobs(), if the counter is greater than a threshold which means
 // there has been a long time after last Cleanup, so we need to Cleanup anyway in SetBlockBlobs.
-func (c *BlobCache) Cleanup(finalized uint64) {
+func (c *BlobMemCache) Cleanup(finalized uint64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/ethstorage/node/node.go
+++ b/ethstorage/node/node.go
@@ -140,6 +140,7 @@ func (n *EsNode) initL2(ctx context.Context, cfg *Config) error {
 		n.daClient,
 		n.db,
 		n.storageManager,
+		downloader.NewBlobMemCache(),
 		cfg.Downloader.DownloadStart,
 		cfg.Downloader.DownloadDump,
 		cfg.L1.L1MinDurationForBlobsRequest,


### PR DESCRIPTION
To enable miner sampling on blob cache, encode blobs immediately after downloading.