### PR TITLE
Fix 'diff not match'

### DIFF
--- a/ethstorage/miner/algorithm_test.go
+++ b/ethstorage/miner/algorithm_test.go
@@ -1,0 +1,78 @@
+// Copyright 2022-2023, EthStorage.
+// For license information, see https://github.com/ethstorage/es-node/blob/main/LICENSE
+
+package miner
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+)
+
+func Test_expectedDiff(t *testing.T) {
+	type args struct {
+		interval       uint64
+		difficulty     *big.Int
+		cutoff         *big.Int
+		diffAdjDivisor *big.Int
+		minDiff        *big.Int
+	}
+	tests := []struct {
+		name string
+		args args
+		want *big.Int
+	}{
+		{
+			"decrease: diff not match case 1",
+			args{
+				1724219196 - 1724218692,
+				big.NewInt(16933920),
+				big.NewInt(7200),
+				big.NewInt(32),
+				big.NewInt(9437184),
+			},
+			big.NewInt(17463105),
+		},
+		{
+			"decrease: diff not match case 2",
+			args{
+				1724243184 - 1724242128,
+				big.NewInt(71922272),
+				big.NewInt(7200),
+				big.NewInt(32),
+				big.NewInt(9437184),
+			},
+			big.NewInt(74169843),
+		},
+		{
+			"no change",
+			args{
+				1723277844 - 1723267236,
+				big.NewInt(25034417035),
+				big.NewInt(7200),
+				big.NewInt(32),
+				big.NewInt(4718592000),
+			},
+			big.NewInt(25034417035),
+		},
+		{
+			"increase",
+			args{
+				1724507676 - 1724507412,
+				big.NewInt(18788404245),
+				big.NewInt(7200),
+				big.NewInt(32),
+				big.NewInt(4718592000),
+			},
+			big.NewInt(19375541877),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fmt.Println("tt.args.interval", tt.args.interval)
+			if got := expectedDiff(tt.args.interval, tt.args.difficulty, tt.args.cutoff, tt.args.diffAdjDivisor, tt.args.minDiff); tt.want.Cmp(got) != 0 {
+				t.Errorf("got  = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/ethstorage/miner/worker.go
+++ b/ethstorage/miner/worker.go
@@ -322,9 +322,12 @@ func (w *worker) updateDifficulty(shardIdx, blockTime uint64) (*big.Int, error) 
 		return nil, err
 	}
 	w.lg.Info("Mining info retrieved", "shard", shardIdx, "lastMineTime", info.LastMineTime, "difficulty", info.Difficulty, "proofsSubmitted", info.BlockMined)
+
+	if blockTime <= info.LastMineTime {
+		return nil, errors.New("minedTs too small")
+	}
 	reqDiff := new(big.Int).Div(maxUint256, expectedDiff(
-		info.LastMineTime,
-		blockTime,
+		blockTime-info.LastMineTime,
 		info.Difficulty,
 		w.config.Cutoff,
 		w.config.DiffAdjDivisor,


### PR DESCRIPTION
Addressing https://github.com/ethstorage/es-node/issues/304.

The current `expectedDiff()` in es-node differs from the implementation in MiningLib.sol, leading to rare cases where the computed difficulty does not match.

The unit test utilizes actual input data including previously failed cases.

reference:
<img width="807" alt="image" src="https://github.com/user-attachments/assets/930e8ad0-7d71-473f-ba55-37c0c4448f13">