### PR TITLE
fix bug: connection with DirInbound may not have addresses in Peerstore.

### DIFF
--- a/ethstorage/p2p/node.go
+++ b/ethstorage/p2p/node.go
@@ -103,8 +103,8 @@ func (n *NodeP2P) init(resourcesCtx context.Context, rollupCfg *rollup.EsConfig,
 					// n.RequestShardList to fetch the shard list of the new node.
 					remoteShardList, e := n.RequestShardList(remotePeerId)
 					if e != nil && len(n.host.Peerstore().Addrs(remotePeerId)) == 0 {
-						// As the node host enable NATService, which will create a new connection with another
-						// peer id and its Addrs will not be set to Peerstore. So if len of peer Addrs is 0 and
+						// As the remote node host may enable NATService, which will create a new connection with another
+						// peer id and its Addrs will not be set to local host's Peerstore. So if len of peer Addrs is 0 and
 						// cannot get the remote node's shard list, then ignore this connection.
 						log.Debug("No addresses to get shard list, return without close conn", "peer", n.host.ID(), "remote peer",
 							remotePeerId, "Direction", conn.Stat().Direction, "remote address", conn.RemoteMultiaddr().String(), "error", e.Error())

--- a/ethstorage/p2p/node.go
+++ b/ethstorage/p2p/node.go
@@ -106,9 +106,8 @@ func (n *NodeP2P) init(resourcesCtx context.Context, rollupCfg *rollup.EsConfig,
 						// As the node host enable NATService, which will create a new connection with another
 						// peer id and its Addrs will not be set to Peerstore. So if len of peer Addrs is 0 and
 						// cannot get the remote node's shard list, then ignore this connection.
-						log.Debug("No addresses to get shard list, return without close conn", "peer", n.host.ID(),
-							"conn peer", conn.LocalPeer(), "remote peer", remotePeerId, "Direction", conn.Stat().Direction,
-							"remote address", conn.RemoteMultiaddr().String())
+						log.Debug("No addresses to get shard list, return without close conn", "peer", n.host.ID(), "remote peer",
+							remotePeerId, "Direction", conn.Stat().Direction, "remote address", conn.RemoteMultiaddr().String(), "error", e.Error())
 						return
 					} else if e != nil {
 						log.Debug("Get remote shard list fail", "peer", remotePeerId, "Direction", conn.Stat().Direction,

--- a/ethstorage/p2p/node.go
+++ b/ethstorage/p2p/node.go
@@ -104,16 +104,20 @@ func (n *NodeP2P) init(resourcesCtx context.Context, rollupCfg *rollup.EsConfig,
 					remoteShardList, e := n.RequestShardList(remotePeerId)
 					if e != nil && len(n.host.Peerstore().Addrs(remotePeerId)) == 0 {
 						// As the node host enable NATService, which will create a new connection with another
-						// peer id and its Addrs will not be set to Peerstore, so if len of peer Addrs is 0 and
+						// peer id and its Addrs will not be set to Peerstore. So if len of peer Addrs is 0 and
 						// cannot get the remote node's shard list, then ignore this connection.
-						log.Debug("No addresses to get shard list, return without close conn", "peer", n.host.ID(), "conn peer", conn.LocalPeer(), "remote peer", remotePeerId, "Direction", conn.Stat().Direction, "remote address", conn.RemoteMultiaddr().String())
+						log.Debug("No addresses to get shard list, return without close conn", "peer", n.host.ID(),
+							"conn peer", conn.LocalPeer(), "remote peer", remotePeerId, "Direction", conn.Stat().Direction,
+							"remote address", conn.RemoteMultiaddr().String())
 						return
 					} else if e != nil {
-						log.Debug("Get remote shard list fail", "peer", remotePeerId, "err", e.Error())
+						log.Debug("Get remote shard list fail", "peer", remotePeerId, "Direction", conn.Stat().Direction,
+							"remote address", conn.RemoteMultiaddr().String(), "err", e.Error())
 						conn.Close()
 						return
 					}
-					log.Debug("Get remote shard list success", "peer", remotePeerId, "shards", remoteShardList)
+					log.Debug("Get remote shard list success", "peer", remotePeerId, "shards", remoteShardList,
+						"Direction", conn.Stat().Direction, "remote address", conn.RemoteMultiaddr().String())
 					n.Host().Peerstore().Put(remotePeerId, protocol.EthStorageENRKey, remoteShardList)
 					shards = protocol.ConvertToShardList(remoteShardList)
 				} else {

--- a/ethstorage/p2p/node.go
+++ b/ethstorage/p2p/node.go
@@ -96,20 +96,19 @@ func (n *NodeP2P) init(resourcesCtx context.Context, rollupCfg *rollup.EsConfig,
 					shards       map[common.Address][]uint64
 					remotePeerId = conn.RemotePeer()
 				)
-				if len(n.host.Peerstore().Addrs(remotePeerId)) == 0 && conn.Stat().Direction == network.DirOutbound {
-					// As the node host enable NATService, which will create a new connection with another
-					// peer id and its Addrs will not be set to Peerstore, so if len of peer Addrs is 0,
-					// then ignore this connection.
-					log.Debug("No addresses to get shard list, return without close conn", "peer", remotePeerId)
-					return
-				}
 				css, err := n.Host().Peerstore().Get(remotePeerId, protocol.EthStorageENRKey)
 				if err != nil {
 					// for node which is new to the ethstorage network, and it dial the nodes which do not contain
 					// the new node's enr, so the nodes do not know its shard list from enr, so it needs to call
 					// n.RequestShardList to fetch the shard list of the new node.
 					remoteShardList, e := n.RequestShardList(remotePeerId)
-					if e != nil {
+					if e != nil && len(n.host.Peerstore().Addrs(remotePeerId)) == 0 {
+						// As the node host enable NATService, which will create a new connection with another
+						// peer id and its Addrs will not be set to Peerstore, so if len of peer Addrs is 0 and
+						// cannot get the remote node's shard list, then ignore this connection.
+						log.Debug("No addresses to get shard list, return without close conn", "peer", n.host.ID(), "conn peer", conn.LocalPeer(), "remote peer", remotePeerId, "Direction", conn.Stat().Direction, "remote address", conn.RemoteMultiaddr().String())
+						return
+					} else if e != nil {
 						log.Debug("Get remote shard list fail", "peer", remotePeerId, "err", e.Error())
 						conn.Close()
 						return

--- a/ethstorage/p2p/node.go
+++ b/ethstorage/p2p/node.go
@@ -96,7 +96,7 @@ func (n *NodeP2P) init(resourcesCtx context.Context, rollupCfg *rollup.EsConfig,
 					shards       map[common.Address][]uint64
 					remotePeerId = conn.RemotePeer()
 				)
-				if len(n.host.Peerstore().Addrs(remotePeerId)) == 0 {
+				if len(n.host.Peerstore().Addrs(remotePeerId)) == 0 && conn.Stat().Direction == network.DirOutbound {
 					// As the node host enable NATService, which will create a new connection with another
 					// peer id and its Addrs will not be set to Peerstore, so if len of peer Addrs is 0,
 					// then ignore this connection.

--- a/ethstorage/p2p/notifications.go
+++ b/ethstorage/p2p/notifications.go
@@ -46,11 +46,11 @@ func (notif *notifications) ListenClose(n network.Network, a ma.Multiaddr) {
 }
 func (notif *notifications) Connected(n network.Network, v network.Conn) {
 	notif.m.IncPeerCount()
-	notif.log.Info("Connected to peer", "peer", v.RemotePeer(), "addr", v.RemoteMultiaddr())
+	notif.log.Info("Connected to peer", "peer", v.RemotePeer(), "Direction", v.Stat().Direction, "addr", v.RemoteMultiaddr())
 }
 func (notif *notifications) Disconnected(n network.Network, v network.Conn) {
 	notif.m.DecPeerCount()
-	notif.log.Info("Disconnected from peer", "peer", v.RemotePeer(), "addr", v.RemoteMultiaddr())
+	notif.log.Info("Disconnected from peer", "peer", v.RemotePeer(), "Direction", v.Stat().Direction, "addr", v.RemoteMultiaddr())
 }
 func (notif *notifications) OpenedStream(n network.Network, v network.Stream) {
 	notif.m.IncStreamCount()


### PR DESCRIPTION
Connection is filtered out when n.host.Peerstore().Addrs(remotePeerId)) == 0. which is added to fix issue https://github.com/ethstorage/go-ethstorage/issues/72. (related PR: https://github.com/ethstorage/go-ethstorage/pull/91)
However, this fix will additionally filter out some connections that should not be ignored. For example, if a connection is coming in connection (Direction == DirInbound), its address may not have been added to Peerstore yet, at this time, the incoming connection would be ignored. The following are the connections shown when stopping the es-node, but only 29 of them are added to the syncclient.
![1726309045211](https://github.com/user-attachments/assets/eb301af8-c37e-4462-8029-6c8d7adb30f6)

**How to Fix**
To ignore the connection without disconnecting which is caused by NAT, this can be done after we get the shard list failure. 

After the change, we will get the following error for that case (temporary change its log level from debug to warning to make it more obvious) 
![1726309105860](https://github.com/user-attachments/assets/c42e29e0-1838-4d50-9446-e757e51880fd)

Running the change on Sepolia test net before and after the change for 10 minutes, and the connected connections increase from 29 to 40.
Before change:
![1726309045197](https://github.com/user-attachments/assets/753c9684-8503-450b-bb67-59262db51245)
After change:
![1726309045113](https://github.com/user-attachments/assets/dd29f55e-3972-44ea-9e2c-562232a51e10)



