### PR TITLE
RPC timeout update

### DIFF
--- a/ethstorage/node/eth_api.go
+++ b/ethstorage/node/eth_api.go
@@ -22,7 +22,7 @@ type ethAPI struct {
 }
 
 const (
-	defaultCallTimeout = 2 * time.Second
+	defaultCallTimeout = 5 * time.Second
 )
 
 var (

--- a/ethstorage/node/eth_api.go
+++ b/ethstorage/node/eth_api.go
@@ -22,7 +22,7 @@ type ethAPI struct {
 }
 
 const (
-	defaultCallTimeout = 5 * time.Second
+	defaultCallTimeout = 10 * time.Second
 )
 
 var (


### PR DESCRIPTION
__Issue to address__

While stored as blobs, some big web resources cannot be loaded thru the web3 gateway, which the console shows:

```
ERRO[2024-09-14 10:11:59] FetchUrl error: internal server error: Post "http://127.0.0.1:8545": context deadline exceeded  
```
__root cause__

The default timeout is too short so the es-node does not have enough time to make eth_esCall to es_geth.

__solution__

The solution is to extend the timeout.