### PR TITLE
add upload logs to Integration test action

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -65,3 +65,15 @@ jobs:
           cd ../../cmd/integration-test-server
           go build
           ./integration-test-server --contract_addr $ES_NODE_CONTRACT_ADDRESS > itserver.log 
+
+      - name: Upload Logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: logs
+          path: |
+            es-node-it-bootnode.log
+            ./integration_tests/scripts/upload.log
+            ./integration_tests/scripts/upload2.log
+            es-node-it.log
+            ./cmd/integration-test-server/itserver.log


### PR DESCRIPTION
Currently, the test logs will be removed after a new integration test starts, add the `upload logs` step to the Integration test to upload them all. After the change, the action page will show the logs as follows:

![1729047004759](https://github.com/user-attachments/assets/642a42d0-c1e9-4f6b-8a6b-e403a4fed873)
