### PR TITLE
update integration test run-on to ubuntu-latest for notification job

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -83,7 +83,7 @@ jobs:
   notification:
     if: ${{ always() }}
     needs: integration-test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Send notification email
         uses: dawidd6/action-send-mail@v3


### PR DESCRIPTION
Currently, the integration-test notification job will fail with the error "Connection timeout" as it runs on self-hosted. 
![1729561989537](https://github.com/user-attachments/assets/475ba361-16d9-42e6-b7e8-d097788ec3b4)
![1729562015111](https://github.com/user-attachments/assets/211806d1-f057-4680-a4e8-5e975fa5f900)


So change the integration test's notification job to run on ubuntu-latest.
https://github.com/ethstorage/es-node/actions/runs/11443530042 ()
![1729562253610](https://github.com/user-attachments/assets/d9ca5cfb-b55b-4552-aeb2-df8eaec8b87f)
![1729562190868](https://github.com/user-attachments/assets/9e43a02b-b4ae-4197-89bd-6e72ea335128)
