### PR TITLE
Use the same code branch as current node in the testnet

### DIFF
--- a/ethstorage/archiver/guide-sepolia.md
+++ b/ethstorage/archiver/guide-sepolia.md
@@ -52,9 +52,9 @@ It is assumed that the above services and components are functioning properly.
 Clone the `op-geth` repository and build the execution client:
 
 ```bash
-git clone https://github.com/ethereum-optimism/op-geth.git
+git clone https://github.com/ethstorage/op-geth.git
 cd op-geth
-git checkout v1.101408.0
+git checkout testnet
 make geth
 ```
 
@@ -117,12 +117,12 @@ Start the client with the following command:
 ## Running op-node
 
 ### Getting the Code
-Clone the Optimism monorepo and check out the `long-term-da` branch:
+Clone the Optimism monorepo and check out the `testnet` branch:
 
 ```bash
 git clone https://github.com/ethstorage/optimism.git
 cd optimism
-git checkout long-term-da
+git checkout testnet
 ```
 
 ### Building the op-node


### PR DESCRIPTION
In the OP Stack testnet current nodes are running with `testnet` branch which support L2 blob tx. To sync with the current OP Stack nodes, we need to use the same branch to avoid sync error.

Test: Rerun the validator node using the `testnet` branch and verified that the block hash the same between the validator and sequencer.