### PR TITLE
Archiver test doc update

### DIFF
--- a/ethstorage/archiver/guide-blob-test.md
+++ b/ethstorage/archiver/guide-blob-test.md
@@ -36,10 +36,10 @@ To download and run a proxy for the Beacon client, execute the following command
 ```bash
 git clone https://github.com/ethstorage/beacon-api-wrapper.git
 cd beacon-api-wrapper
-go run cmd/main.go -r 1800
+go run cmd/main.go -r 3 -b http://88.99.30.186:3500
 ```
 
-This proxy functions like a standard Beacon API, except that it has a much shorter blob retention period—1800 seconds or 150 slots in this case. Consequently, when a `blob_sidecars` request is made for blobs older than this time frame, it will return an empty list: `{"data":[]}`.
+This proxy functions like a standard Beacon API, except that it has a much shorter blob retention period - 3 epochs or 96 slots in this case. Consequently, when a `blob_sidecars` request is made for blobs older than this time frame, it will return an empty list: `{"data":[]}`.
 
 Note: The default RPC port for the mocked Beacon API is 3600.
 

--- a/ethstorage/archiver/guide-devnet.md
+++ b/ethstorage/archiver/guide-devnet.md
@@ -9,9 +9,10 @@
    - [Fill Out Environment Variables](#fill-out-environment-variables)
 2. [L1 Setup](#l1-setup)
    - [Starting L1](#starting-l1)
+   - [Running a Proxy of L1 Beacon to Mock Short Retention Period of Blobs](#running-a-proxy-of-l1-beacon-to-mock-short-retention-period-of-blobs)
+3. [Deploying Contracts](#deploying-contracts)
    - [Deploying EthStorage Contracts](#deploying-ethstorage-contracts)
-   - [Deploy BatchInbox](#deploy-batchinbox)
-   - [Running a Proxy of L1 Beacon](#running-a-proxy-of-l1-beacon)
+   - [Deploying BatchInbox Contract](#deploying-batchinbox-contract)
 3. [Running EthStorage Node](#running-ethstorage-node)
    - [Installation](#installation)
    - [Initialization](#initialization)
@@ -115,6 +116,19 @@ This command will start the following services:
 
 Now, navigate to the parent directory in preparation for the next steps.
 
+### Running a Proxy of L1 Beacon to Mock Short Retention Period of Blobs
+
+The following commands start a proxy to Beacon API with a shorter blobs retension period:
+```bash
+git clone https://github.com/ethstorage/beacon-api-wrapper.git
+cd beacon-api-wrapper
+go run cmd/main.go -b http://localhost:5052 -p 3602 -g $GENESIS_TIME -r 2
+```
+If a blob request is within the latest 2 epochs or 64 slots, the proxy will retrieve blobs from `http://localhost:5052`. For requests older than that, it will return an empty list.
+This setup allows you to test archive service effectively. 
+
+## Deploying Contracts
+
 ### Deploying EthStorage Contracts
 
 Begin by cloning the EthStorage contract repository and install the dependencies:
@@ -122,7 +136,7 @@ Begin by cloning the EthStorage contract repository and install the dependencies
 git clone https://github.com/ethstorage/storage-contracts-v1.git
 cd storage-contracts-v1
 git checkout op-devnet
-npm install
+npm run install:all
 ``` 
 
 Create a `.env` file and populate it with the following content:
@@ -142,7 +156,7 @@ export ES_CONTRACT=0x9B75f686F348d18AF9A4b98e0290D24350d742c4  # replace with th
 ```
 Now, navigate to the parent directory in preparation for the next steps.
 
-### Deploy BatchInbox
+### Deploying BatchInbox Contract
 
 Clone and build the BatchInbox contract:
 ```bash
@@ -182,28 +196,6 @@ Update the value of `batchInboxAddress` with the address of the contract you jus
 
 Now, navigate to the parent directory in preparation for the next steps.
 
-### Running a Proxy of L1 Beacon
-
-For the convenience of testing, you will start a proxy for the Beacon API with a shorter blob retention period.
-
-First retrieve the beacon genesis time for later use:
-```bash
-curl -s http://localhost:5052/eth/v1/beacon/genesis | jq -r '.data.genesis_time'
-
-1732529739
-
-export GENESIS_TIME=1732529739 // replace with the actual timestamp
-```
-
-The following commands start a proxy to Beacon API with a shorter blobs retension period:
-```bash
-git clone https://github.com/ethstorage/beacon-api-wrapper.git
-cd beacon-api-wrapper
-go run cmd/main.go -b http://localhost:5052 -p 3602 -g $GENESIS_TIME -r 1200
-```
-This setup allows you to test archive service effectively. 
-For blob requests, if the request is within the latest 1200 seconds or 100 slots, the proxy will retrieve blobs from `http://localhost:5052`. For requests older than that, it will return an empty list.
-
 ## Running EthStorage Node
 
 
@@ -227,6 +219,15 @@ Initialize es-node:
 ```
 
 ### Running ES Node in Archiver Mode
+
+Retrieve the beacon genesis time for later use:
+```bash
+curl -s http://localhost:5052/eth/v1/beacon/genesis | jq -r '.data.genesis_time'
+
+1732529739
+
+export GENESIS_TIME=1732529739 // replace with the actual timestamp
+```
 
 Finally, run the es-node:
 

--- a/ethstorage/archiver/guide-devnet.md
+++ b/ethstorage/archiver/guide-devnet.md
@@ -216,9 +216,7 @@ This command will start the following services:
 
 Now, navigate to the parent directory in preparation for the next steps.
 
-The following steps will add an additional OP Stack instance in validator mode, configured to sync expired blob data from the es-node. This aims to verify that the functions of the derivation pipeline are working correctly with the BatchInbox contract and the EthStorage archive service. 
-
-Note: To ensure that the new OP Stack instance is genuinely derived from the "expired" blobs stored by EthStorage, you may need to wait for at least 100 slots before starting the next steps.
+The following steps will add an additional OP Stack instance in validator mode only download blobs from the Beacon API proxy at first. 
 
 ### Starting OP Geth
 
@@ -272,6 +270,8 @@ Now, navigate to the parent directory in preparation for the next steps.
 
 ### Starting OP Node
 
+Note: To ensure that the new OP Stack instance is trying to derived from the "expired" blobs, you may need to wait for at least 64 slots before starting the next steps, according to the setting of the Beacon proxy.
+
 Enter the Optimism monorepo and execute the following commands to start op-node as a validator:
 
 ```bash
@@ -296,7 +296,7 @@ make op-node
 1. P2P is disabled so that it can only sync data from L1.
 2. The L1 beacon URL is directed to the beacon proxy, where blobs expire quickly.
 
-You can observe that the validator node is unable to sync properly because it cannot retrieve expired blobs. The next steps are to set up an EthStorage node to store the expired blobs for the rollup.
+You can observe that the validator node is unable to sync properly with "derivation failed" error due to "failed to fetch blobs". 
 
 Now, navigate to the parent directory in preparation for the next steps.
 

--- a/ethstorage/archiver/guide-devnet.md
+++ b/ethstorage/archiver/guide-devnet.md
@@ -131,6 +131,8 @@ go run cmd/main.go -b http://localhost:5052 -p 3602 -r 3
 If a blob request is within the latest 3 epochs or 96 slots, the proxy will retrieve blobs from the Beacon URL (`http://localhost:5052`). For requests older than that, it will return an empty list.
 This setup allows you to test the archive service effectively. 
 
+Now, navigate to the parent directory in preparation for the next steps.
+
 ## EthStorage Setup
 
 ### Deploying EthStorage Contracts
@@ -213,6 +215,7 @@ Shortly after the es-node starts, it will listen for the storage contract, downl
 
 Please note that this is a simplified version of the es-node designed solely for data access. In a standard EthStorage network, a p2p network is formed by storage providers who secure the data using a sophisticated proof-of-storage algorithm. For detailed information, please refer to [the documentation](docs.ethstorage.io).
 
+Now, navigate to the parent directory in preparation for the next steps.
 
 ## L2 Setup
 
@@ -258,11 +261,9 @@ Finally, navigate to the Optimism monorepo and locate `batchInboxAddress` in the
 ```
 Update the value of `batchInboxAddress` with the address of the contract you just deployed. 
 
-Now, navigate to the parent directory in preparation for the next steps.
-
 ### Running L2
 
-Enter the Optimism monorepo and start the Layer 2 environment by executing the following command:
+In the Optimism monorepo, start the Layer 2 environment by executing the following command:
 ```bash
 make devnet-up-l2
 ```
@@ -331,7 +332,7 @@ Now, navigate to the parent directory in preparation for the next steps.
 
 ### Starting OP Node
 
-Note: To ensure that the new OP Stack instance is trying to derived from the "expired" blobs, you may need to wait for at least 64 slots before starting the next steps, according to the setting of the Beacon proxy.
+Note: To ensure that the new OP Stack instance is trying to derived from the "expired" blobs, you may need to wait for at least 96 slots before starting the next steps, according to the setting of the Beacon proxy.
 
 Enter the Optimism monorepo and execute the following commands to start op-node as a validator:
 
@@ -357,13 +358,11 @@ make op-node
 1. P2P is disabled so that it can only sync data from L1.
 2. The L1 beacon URL is directed to the beacon proxy, where blobs expire quickly.
 
-You can observe that the validator node is unable to sync properly with "derivation failed" error due to "failed to fetch blobs". 
-
-Now, navigate to the parent directory in preparation for the next steps.
+You can observe that the validator node is unable to sync properly with "derivation failed" error due to "failed to fetch blobs", which is a expected result because there is no way to retreive the expired blobs.
 
 ### Restarting OP Node With the Archiver Configured
 
-Enter the Optimism monorepo, stop the running op-node, and re-start op-node with the same command in [this section](#starting-op-node) but with an extra option:
+Now, stop the running op-node, and re-start op-node with the same command in [the last step](#starting-op-node) but with an extra option:
 
 ```bash
 --l1.beacon-archiver http://localhost:6678

--- a/ethstorage/archiver/guide-devnet.md
+++ b/ethstorage/archiver/guide-devnet.md
@@ -34,6 +34,8 @@ The test framework is based on the Bedrock devnet but allows for separate contro
 - The deployment of EthStorage contracts and BatchInbox contract that help to store batch data into EthStorage. 
 - Launch an EthStorage node (es-node) in archiver mode. 
 
+You will have an intuitive experience and clear understanding of the difference made by EthStorage archive service as a long-term data availability solution.
+
 ## Preparations
 
 ### Software Dependencies
@@ -123,9 +125,9 @@ The following commands start a proxy to Beacon API with a shorter blobs retensio
 ```bash
 git clone https://github.com/ethstorage/beacon-api-wrapper.git
 cd beacon-api-wrapper
-go run cmd/main.go -b http://localhost:5052 -p 3602 -g $GENESIS_TIME -r 2
+go run cmd/main.go -b http://localhost:5052 -p 3602 -r 3
 ```
-If a blob request is within the latest 2 epochs or 64 slots, the proxy will retrieve blobs from `http://localhost:5052`. For requests older than that, it will return an empty list.
+If a blob request is within the latest 3 epochs or 96 slots, the proxy will retrieve blobs from the Beacon URL (`http://localhost:5052`). For requests older than that, it will return an empty list.
 This setup allows you to test archive service effectively. 
 
 ## Deploying Contracts
@@ -331,6 +333,7 @@ curl -s http://localhost:5052/eth/v1/beacon/genesis | jq -r '.data.genesis_time'
 
 export GENESIS_TIME=1732529739 // replace with the actual timestamp
 ```
+Note: Before proceeding to the next step of launching the es-node, ensure that at least 2 epochs (approximately 13 minutes) have passed since the EthStorage contracts were deployed in [this step](#deploying-ethstorage-contracts), as the es-node needs to read the finalized states of the contract.
 
 Finally, run the es-node:
 

--- a/ethstorage/archiver/guide-devnet.md
+++ b/ethstorage/archiver/guide-devnet.md
@@ -358,7 +358,7 @@ make op-node
 1. P2P is disabled so that it can only sync data from L1.
 2. The L1 beacon URL is directed to the beacon proxy, where blobs expire quickly.
 
-You can observe that the validator node is unable to sync properly with "derivation failed" error due to "failed to fetch blobs", which is a expected result because there is no way to retreive the expired blobs.
+You can observe that the validator node is unable to sync properly with "derivation failed" error due to "failed to fetch blobs", which is an expected result because there is no way to retreive the expired blobs.
 
 ### Restarting OP Node With the Archiver Configured
 


### PR DESCRIPTION
Fix comments during the demo. Major changes include:

- Reorg the table of contents
- Move the es-node setup to a later point to compare results with and without the archive service.
- Correct the incorrect command
- Update the beacon-api-wrapper to use epoch as the unit of retention time (per EIP-4844, which defines the retention period as 4096 epochs).
- Address inconsistencies in titles, etc.

Changes verified in the test environment.