### PR TITLE
Fix missing slash of l2 script

### DIFF
--- a/run-l2.sh
+++ b/run-l2.sh
@@ -6,5 +6,5 @@
   --l1.block_time 2 \
   --da.url http://5.9.87.214:8888 \
   --randao.url http://88.99.30.186:8545 \
-  --p2p.bootnodes enr:-Li4QFWB-bdjo4EVuvJmJ4GmMuwa0RcFdtdpA6yUxTdU0QE8aG_q8eZa9B4vu2LGPTbspqFtMBCuJpjG0q178SY7H1yGAZP7b35dimV0aHN0b3JhZ2XbAYDY15RkADrb3zAU9-OPxr51LrBHuV2omsGAgmlkgnY0gmlwhEFtMpGJc2VjcDI1NmsxoQMw4i1lk4EjCD_4os-PSrC9y1BrDim_olfCCPNBoXSkWIN0Y3CCJAaDdWRwgnZh
+  --p2p.bootnodes enr:-Li4QFWB-bdjo4EVuvJmJ4GmMuwa0RcFdtdpA6yUxTdU0QE8aG_q8eZa9B4vu2LGPTbspqFtMBCuJpjG0q178SY7H1yGAZP7b35dimV0aHN0b3JhZ2XbAYDY15RkADrb3zAU9-OPxr51LrBHuV2omsGAgmlkgnY0gmlwhEFtMpGJc2VjcDI1NmsxoQMw4i1lk4EjCD_4os-PSrC9y1BrDim_olfCCPNBoXSkWIN0Y3CCJAaDdWRwgnZh \
  $@


### PR DESCRIPTION
Fix the error when running `run-l2-rpc.sh`: 

```
$ ./run-l2-rpc.sh
========== build info ==================
EthStorage node version v0.1.16-f533a6fc-1735115453
Build date: Wed Dec 25 16:54:09 CST 2024
System version: amd64/darwin
Golang version: go1.22.3
========================================
t=2024-12-25T16:57:28+0800 lvl=info msg="Configuring EthStorage Node"
INFO [12-25|16:57:28.260] Read L1 config                           l1.rpc=http://5.9.87.214:8545
INFO [12-25|16:57:28.260] Read L1 config                           l1.beacon=http://88.99.30.186:3500
INFO [12-25|16:57:28.260] Loaded storage config                    l1Contract=0x64003adbdf3014f7E38FC6BE752EB047b95da89A miner=0x0000000000000000000000000000000000000000
INFO [12-25|16:57:28.857] Read uint from contract                  field=maxKvSizeBits value=17
INFO [12-25|16:57:29.143] Read uint from contract                  field=shardEntryBits value=22
ERROR[12-25|16:57:29.143] Unable to create the rollup node config  error="failed to load miner config: miner address cannot be empty"
CRIT [12-25|16:57:29.143] Application failed                       message="failed to load miner config: miner address cannot be empty"
./run-l2.sh: line 10: --rpc.addr: command not found
```
