### PR TITLE
Dashboard: add chainID to contract address for dashboard

### DIFF
--- a/cmd/dashboard/config.json
+++ b/cmd/dashboard/config.json
@@ -2,15 +2,17 @@
   {
     "name":"Sepolia",
     "type": "l1",
-    "contract":"0x804C520d3c084C805E37A35E90057Ac32831F96f",
     "rpc":"http://88.99.30.186:8545",
+    "chainID": 3333,
+    "contract":"0x804C520d3c084C805E37A35E90057Ac32831F96f",
     "startNumber": 5528000
   },
   {
     "name":"QKC L2 ",
     "type": "l2",
-    "contract":"0x64003adbdf3014f7E38FC6BE752EB047b95da89A",
     "rpc":"http://5.9.87.214:8545",
+    "chainID": 3337,
+    "contract":"0x64003adbdf3014f7E38FC6BE752EB047b95da89A",
     "startNumber": 133640
   }
 ]


### PR DESCRIPTION
We currently use a contract address to differentiate between different networks, but different networks would still use the same one. So add chain ID ahead of contract address to differentiate different networks.


![1736265000548](https://github.com/user-attachments/assets/bb7c2e44-62a9-4470-8218-bc003816a40c)
