### PR TITLE
es-node tool to fix a specific kv entry

### DIFF
--- a/cmd/es-node/main.go
+++ b/cmd/es-node/main.go
@@ -101,8 +101,8 @@ func main() {
 		{
 			Name:      "sync",
 			Aliases:   []string{"s"},
-			Usage:     fmt.Sprintf("Sync data specified by `%s` from RPC", kvIndexFlagName),
-			UsageText: fmt.Sprintf("Sync data specified by `%s` from RPC", kvIndexFlagName),
+			Usage:     fmt.Sprintf("Download a blob from an RPC node and update it in local storage. Type 'es-node sync --help' for more information."),
+			UsageText: fmt.Sprintf("Sync local data specified by `%s` from RPC specified by `%s`", kvIndexFlagName, esRpcFlagName),
 			Flags: []cli.Flag{
 				cli.Uint64Flag{
 					Name:  kvIndexFlagName,
@@ -322,10 +322,10 @@ func EsNodeSync(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get meta: %w", err)
 	}
+	lg.Info("Query meta from contract done", "kvIndex", kvIndex, "meta", common.Hash(meta[0]).Hex())
+	// query blob
 	var commit common.Hash
 	copy(commit[:], meta[0][32-ethstorage.HashSizeInContract:32])
-	lg.Info("Query meta from contract done", "kvIndex", kvIndex, "commit", commit.Hex())
-	// query blob
 	blob, err := downloadBlobFromRPC(esRpc, uint64(kvIndex), commit)
 	if err != nil {
 		return fmt.Errorf("failed to download blob from RPC: %w", err)

--- a/cmd/es-node/utils.go
+++ b/cmd/es-node/utils.go
@@ -4,9 +4,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"math/big"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -14,10 +17,15 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethstorage/go-ethstorage/ethstorage"
 	es "github.com/ethstorage/go-ethstorage/ethstorage"
+	"github.com/ethstorage/go-ethstorage/ethstorage/flags"
 	"github.com/ethstorage/go-ethstorage/ethstorage/storage"
 	"github.com/urfave/cli"
 )
@@ -27,6 +35,8 @@ const (
 	shardLenFlagName     = "shard_len"
 	shardIndexFlagName   = "shard_index"
 	encodingTypeFlagName = "encoding_type"
+	kvIndexFlagName      = "kv_index"
+	esRpcFlagName        = "es_rpc"
 )
 
 func initStorageConfig(ctx context.Context, client *ethclient.Client, l1Contract, miner common.Address) (*storage.StorageConfig, error) {
@@ -206,4 +216,67 @@ func readRequiredFlag(ctx *cli.Context, flag cli.StringFlag) string {
 	value := ctx.String(name)
 	log.Info("Read flag", "name", name, "value", value)
 	return value
+}
+
+func downloadBlobFromRPC(endpoint string, kvIndex uint64, hash common.Hash) ([]byte, error) {
+	rpcClient, err := rpc.DialOptions(context.Background(), endpoint, rpc.WithHTTPClient(http.DefaultClient))
+	if err != nil {
+		return nil, err
+	}
+
+	var result hexutil.Bytes
+	if err := rpcClient.Call(&result, "es_getBlob", kvIndex, hash, 0, 0, 4096*32); err != nil {
+		return nil, err
+	}
+
+	var blob kzg4844.Blob
+	copy(blob[:], result)
+	commitment, err := kzg4844.BlobToCommitment(&blob)
+	if err != nil {
+		return nil, fmt.Errorf("blobToCommitment failed: %w", err)
+	}
+	blobhash := common.Hash(kzg4844.CalcBlobHashV1(sha256.New(), &commitment))
+	if bytes.Compare(blobhash[:es.HashSizeInContract], hash[:es.HashSizeInContract]) != 0 {
+		return nil, fmt.Errorf("invalid blobhash for %d want: %x, got: %x", kvIndex, hash, blobhash)
+	}
+
+	return result, nil
+}
+
+func initShardManager(ctx *cli.Context, l1Rpc string, l1contract common.Address) (*es.ShardManager, error) {
+	miner := readRequiredFlag(ctx, flags.StorageMiner)
+	if !common.IsHexAddress(miner) {
+		return nil, fmt.Errorf("invalid miner address %s", miner)
+	}
+	cctx := context.Background()
+	client, err := ethclient.DialContext(cctx, l1Rpc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to the Ethereum client: %w", err)
+	}
+	defer client.Close()
+
+	storageCfg, err := initStorageConfig(cctx, client, l1contract, common.HexToAddress(miner))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load storage config: %w", err)
+	}
+	if !ctx.IsSet(flags.StorageFiles.Name) {
+		return nil, fmt.Errorf("flag is required: %s", flags.StorageFiles.Name)
+	}
+	storageCfg.Filenames = ctx.StringSlice(flags.StorageFiles.Name)
+	shardManager := ethstorage.NewShardManager(storageCfg.L1Contract, storageCfg.KvSize, storageCfg.KvEntriesPerShard, storageCfg.ChunkSize)
+	for _, filename := range storageCfg.Filenames {
+		fmt.Printf("Adding data file %s\n", filename)
+		df, err := ethstorage.OpenDataFile(filename)
+		if err != nil {
+			return nil, fmt.Errorf("open data file failed: %w", err)
+		}
+		if df.Miner() != storageCfg.Miner {
+			return nil, fmt.Errorf("miner mismatches data file")
+		}
+		shardManager.AddDataFileAndShard(df)
+	}
+	if shardManager.IsComplete() != nil {
+		return nil, fmt.Errorf("data files are not completed")
+	}
+	return shardManager, nil
 }

--- a/cmd/es-node/utils.go
+++ b/cmd/es-node/utils.go
@@ -225,6 +225,7 @@ func downloadBlobFromRPC(endpoint string, kvIndex uint64, hash common.Hash) ([]b
 	}
 
 	var result hexutil.Bytes
+	// kvIndex, blobHash, encodeType, offset, length
 	if err := rpcClient.Call(&result, "es_getBlob", kvIndex, hash, 0, 0, 4096*32); err != nil {
 		return nil, err
 	}
@@ -236,6 +237,7 @@ func downloadBlobFromRPC(endpoint string, kvIndex uint64, hash common.Hash) ([]b
 		return nil, fmt.Errorf("blobToCommitment failed: %w", err)
 	}
 	blobhash := common.Hash(kzg4844.CalcBlobHashV1(sha256.New(), &commitment))
+	fmt.Printf("blobhash from blob: %x\n", blobhash)
 	if bytes.Compare(blobhash[:es.HashSizeInContract], hash[:es.HashSizeInContract]) != 0 {
 		return nil, fmt.Errorf("invalid blobhash for %d want: %x, got: %x", kvIndex, hash, blobhash)
 	}

--- a/ethstorage/storage_manager.go
+++ b/ethstorage/storage_manager.go
@@ -110,7 +110,7 @@ func (s *StorageManager) DownloadFinished(newL1 int64, kvIndices []uint64, blobs
 
 			var err error = nil
 			for _, idx := range insertIdx {
-				c := prepareCommit(commits[idx])
+				c := PrepareCommit(commits[idx])
 				// if return false, just ignore because we are not interested in it
 				_, err = s.shardManager.TryWriteEncoded(kvIndices[idx], blobs[idx], c)
 				if err != nil {
@@ -145,7 +145,7 @@ func (s *StorageManager) DownloadFinished(newL1 int64, kvIndices []uint64, blobs
 	return nil
 }
 
-func prepareCommit(commit common.Hash) common.Hash {
+func PrepareCommit(commit common.Hash) common.Hash {
 	c := common.Hash{}
 	copy(c[0:HashSizeInContract], commit[0:HashSizeInContract])
 
@@ -309,7 +309,7 @@ func (s *StorageManager) commitEncodedBlob(kvIndex uint64, encodedBlob []byte, c
 		return nil
 	}
 
-	c := prepareCommit(commit)
+	c := PrepareCommit(commit)
 
 	success, err = s.shardManager.TryWriteEncoded(kvIndex, encodedBlob, c)
 	if !success || err != nil {

--- a/ethstorage/storage_manager_test.go
+++ b/ethstorage/storage_manager_test.go
@@ -203,7 +203,7 @@ func TestStorageManager_DownloadFinished(t *testing.T) {
 
 	meta := common.Hash{}
 	copy(meta[:], bs)
-	if meta != prepareCommit(h) {
+	if meta != PrepareCommit(h) {
 		t.Fatal("failed to write meta", err)
 	}
 }
@@ -229,7 +229,7 @@ func TestStorageManager_CommitBlobs(t *testing.T) {
 
 	meta := common.Hash{}
 	copy(meta[:], bs)
-	if meta != prepareCommit(h) {
+	if meta != PrepareCommit(h) {
 		t.Fatal("failed to write meta", err)
 	}
 }
@@ -250,7 +250,7 @@ func TestStorageManager_DownloadAllMeta(t *testing.T) {
 
 	meta := common.Hash{}
 	copy(meta[:], bs)
-	if meta != prepareCommit(h) {
+	if meta != PrepareCommit(h) {
 		t.Fatal("failed to compare meta", err)
 	}
 }

--- a/sync.sh
+++ b/sync.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# usage:
+# env ES_NODE_STORAGE_MINER=<miner> ./sync.sh --kv_index <index>
+
+executable="./build/bin/es-node"
+data_dir="./es-data"
+file_flags=""
+
+for file in ${data_dir}/shard-[0-9]*.dat; do 
+    if [ -f "$file" ]; then 
+        file_flags+=" --storage.files $file"
+    fi
+done
+start_flags=" sync \
+  --datadir $data_dir \
+  $file_flags \
+  --storage.l1contract 0x804C520d3c084C805E37A35E90057Ac32831F96f \
+  --l1.rpc http://88.99.30.186:8545 \
+  --es_rpc http://65.108.236.27:9540 \
+  $@"
+
+exec $executable $start_flags

--- a/sync.sh
+++ b/sync.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Sync local data specified by `--kv_index` from RPC
 # usage:
 # env ES_NODE_STORAGE_MINER=<miner> ./sync.sh --kv_index <index>
 


### PR DESCRIPTION
An es-node subcommand to download a blob from an RPC node and update it in local storage. This tool can fix a data entry that was accidentally incorrect.

Usage example:
```bash
env ES_NODE_STORAGE_MINER=0x4b07e60490BE95c03d41F63203De9b51657A4C1a ./sync.sh --kv_index=2012299
```

The hash can be checked and verified using:
```bash
cd cmd/es-utils
go build
./es-utils meta_read --filename ../../es-data/shard-0.dat  --kv_idx=2012299  --kv_entries=8192 --kv_size 131072 --chunk_size 131072
```

incorrect  hash
>01abcdf2f4528e806a2a89c452e1c38209180dfd4db4a8c08000000000000000

correct hash
>01aa945c93ead8b4630b48e3b380864b0c663c2383a4d6d48000000000000000