### PR TITLE
fix swc build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.23'
 
       - name: Set up build environment
         if: matrix.os == 'ubuntu-latest'
@@ -45,8 +45,8 @@ jobs:
           mkdir -p ${{ env.BIN_DIR }}/snarkbuild
           mkdir -p ${{ env.BIN_DIR }}/snark_lib/zkey
           cp -r ethstorage/prover/snark_lib ${{ env.BIN_DIR }}
-          cp init.sh ${{ env.BUILD_DIR }}
-          cp run.sh ${{ env.BUILD_DIR }}
+          cp init.sh init-l2.sh ${{ env.BUILD_DIR }}
+          cp run.sh run-l2.sh ${{ env.BUILD_DIR }}
 
       - name: Build
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,8 +45,7 @@ jobs:
           mkdir -p ${{ env.BIN_DIR }}/snarkbuild
           mkdir -p ${{ env.BIN_DIR }}/snark_lib/zkey
           cp -r ethstorage/prover/snark_lib ${{ env.BIN_DIR }}
-          cp init.sh init-l2.sh ${{ env.BUILD_DIR }}
-          cp run.sh run-l2.sh ${{ env.BUILD_DIR }}
+          cp *.sh ${{ env.BUILD_DIR }}
 
       - name: Build
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,8 @@ RUN apk add --no-cache bash curl libstdc++ gcompat libgomp nodejs npm
 RUN npm install -g snarkjs
 
 # Entrypoint
-COPY --from=builder /es-node/init.sh /es-node/
-COPY --from=builder /es-node/run.sh /es-node/
-RUN chmod +x /es-node/init.sh /es-node/run.sh
+COPY --from=builder /es-node/*.sh /es-node/
+RUN chmod +x /es-node/*.sh
 WORKDIR /es-node
 
 EXPOSE 9545 9222 30305/udp


### PR DESCRIPTION
Fix the issue that the l2 scripts are not included in pre-built binaries.

Tests have been done on ax101, where the `init-l2.sh` and `run-l2.sh` in the prebuilt were successfully executed to sync data and sampling in the SWC testnet.

Same tests done to Docker releases.