### PR TITLE
 Add FetchBlob to SyncClient to support fetching a single blob from the network via p2p

### DIFF
--- a/ethstorage/p2p/node.go
+++ b/ethstorage/p2p/node.go
@@ -227,6 +227,10 @@ func (n *NodeP2P) RequestL2Range(ctx context.Context, start, end uint64) (uint64
 	return n.syncCl.RequestL2Range(start, end)
 }
 
+func (n *NodeP2P) FetchBlob(index uint64, commit common.Hash) ([]byte, error) {
+	return n.syncCl.FetchBlob(index, commit)
+}
+
 // RequestShardList fetches shard list from remote peer
 func (n *NodeP2P) RequestShardList(remotePeer peer.ID) ([]*protocol.ContractShards, error) {
 	remoteShardList := make([]*protocol.ContractShards, 0)

--- a/ethstorage/p2p/protocol/sync_test.go
+++ b/ethstorage/p2p/protocol/sync_test.go
@@ -657,7 +657,7 @@ func TestSync_RequestL2List(t *testing.T) {
 		assert.NoError(t, err)
 		root, _ := prover.GetRoot(blob, 0, 0)
 		commit := generateMetadata(root)
-		assert.Equal(t, meta, commit)
+		assert.Equal(t, common.BytesToHash(meta), commit)
 	}
 }
 

--- a/ethstorage/p2p/protocol/sync_test.go
+++ b/ethstorage/p2p/protocol/sync_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"math/big"
 	"math/rand"
 	"os"
@@ -649,6 +650,15 @@ func TestSync_RequestL2List(t *testing.T) {
 		t.Fatal(err)
 	}
 	verifyKVs(data, excludedList, t)
+
+	for _, index := range indexes {
+		meta, _, _ := sm.TryReadMeta(index)
+		blob, err := syncCl.FetchBlob(index, common.BytesToHash(meta))
+		assert.NoError(t, err)
+		root, _ := prover.GetRoot(blob, 0, 0)
+		commit := generateMetadata(root)
+		assert.Equal(t, meta, commit)
+	}
 }
 
 // TestSaveAndLoadSyncStatus test save sync state to DB for tasks and load sync state from DB for tasks.

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -625,7 +625,7 @@ func (s *SyncClient) FetchBlob(kvIndex uint64, commit common.Hash) ([]byte, erro
 			if val.BlobIndex != kvIndex {
 				continue
 			}
-			if bytes.Equal(val.BlobCommit[0:ethstorage.HashSizeInContract], commit[0:ethstorage.HashSizeInContract]) {
+			if !bytes.Equal(val.BlobCommit[0:ethstorage.HashSizeInContract], commit[0:ethstorage.HashSizeInContract]) {
 				log.Warn("FetchBlob failed", "peer", pr.ID(), "expected commit", commit.Hex(), "actual commit", val.BlobCommit.Hex())
 				continue
 			}

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -608,8 +608,9 @@ func (s *SyncClient) RequestL2Range(start, end uint64) (uint64, error) {
 
 func (s *SyncClient) FetchBlob(kvIndex uint64, commit common.Hash) ([]byte, error) {
 	if len(s.peers) == 0 {
-		return []byte{}, fmt.Errorf("no peer can be used to send requests")
+		return nil, fmt.Errorf("no peer can be used to send requests")
 	}
+
 	for _, pr := range s.peers {
 		var packet BlobsByListPacket
 		var payload *BlobPayload = nil
@@ -617,13 +618,14 @@ func (s *SyncClient) FetchBlob(kvIndex uint64, commit common.Hash) ([]byte, erro
 		_, err := pr.RequestBlobsByList(rand.Uint64(), s.storageManager.ContractAddress(), kvIndex/s.storageManager.KvEntries(), []uint64{kvIndex}, &packet)
 		if err != nil {
 			log.Warn("FetchBlob failed", "error", err)
+			continue
 		}
 
 		for _, val := range packet.Blobs {
 			if val.BlobIndex != kvIndex {
 				continue
 			}
-			if val.BlobCommit.Cmp(commit) != 0 {
+			if bytes.Equal(val.BlobCommit[0:ethstorage.HashSizeInContract], commit[0:ethstorage.HashSizeInContract]) {
 				log.Warn("FetchBlob failed", "peer", pr.ID(), "expected commit", commit.Hex(), "actual commit", val.BlobCommit.Hex())
 				continue
 			}
@@ -646,7 +648,8 @@ func (s *SyncClient) FetchBlob(kvIndex uint64, commit common.Hash) ([]byte, erro
 
 		return decodedBlob, nil
 	}
-	return []byte{}, fmt.Errorf("fail to fetch blob from peer")
+
+	return nil, fmt.Errorf("fail to fetch blob from peers")
 }
 
 func (s *SyncClient) RequestL2List(indexes []uint64) (uint64, error) {

--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -596,13 +596,57 @@ func (s *SyncClient) RequestL2Range(start, end uint64) (uint64, error) {
 		if err != nil {
 			return 0, err
 		}
-		_, _, _, err = s.onResult(packet.Blobs)
+		_, _, inserted, err := s.onResult(packet.Blobs)
 		if err != nil {
 			return 0, err
 		}
-		return id, nil
+
+		return uint64(len(inserted)), nil
 	}
 	return 0, fmt.Errorf("no peer can be used to send requests")
+}
+
+func (s *SyncClient) FetchBlob(kvIndex uint64, commit common.Hash) ([]byte, error) {
+	if len(s.peers) == 0 {
+		return []byte{}, fmt.Errorf("no peer can be used to send requests")
+	}
+	for _, pr := range s.peers {
+		var packet BlobsByListPacket
+		var payload *BlobPayload = nil
+
+		_, err := pr.RequestBlobsByList(rand.Uint64(), s.storageManager.ContractAddress(), kvIndex/s.storageManager.KvEntries(), []uint64{kvIndex}, &packet)
+		if err != nil {
+			log.Warn("FetchBlob failed", "error", err)
+		}
+
+		for _, val := range packet.Blobs {
+			if val.BlobIndex != kvIndex {
+				continue
+			}
+			if val.BlobCommit.Cmp(commit) != 0 {
+				log.Warn("FetchBlob failed", "peer", pr.ID(), "expected commit", commit.Hex(), "actual commit", val.BlobCommit.Hex())
+				continue
+			}
+			payload = val
+		}
+
+		if payload == nil {
+			continue
+		}
+
+		decodedBlob, success := s.decodeKV(payload)
+		if !success {
+			continue
+		}
+
+		success = s.checkBlobCommit(decodedBlob, payload)
+		if !success {
+			continue
+		}
+
+		return decodedBlob, nil
+	}
+	return []byte{}, fmt.Errorf("fail to fetch blob from peer")
 }
 
 func (s *SyncClient) RequestL2List(indexes []uint64) (uint64, error) {


### PR DESCRIPTION
 Add FetchBlob to SyncClient to support fetching a single blob from the network via p2p, it will use by [pr 392](https://github.com/ethstorage/es-node/pull/392/files).

interface: 
func FetchBlob(index uint64, commit common.Hash) ([]byte, error) 

