### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/cmd/es-utils/utils/utils.go
+++ b/cmd/es-utils/utils/utils.go
@@ -203,10 +203,7 @@ func ConvertToBlobs(data []byte) []kzg4844.Blob {
 	blobs := []kzg4844.Blob{}
 	blobIndex := 0
 	for i := 0; i < len(data); i += params.BlobTxFieldElementsPerBlob * 32 {
-		max := i + params.BlobTxFieldElementsPerBlob*32
-		if max > len(data) {
-			max = len(data)
-		}
+		max := min(i+params.BlobTxFieldElementsPerBlob*32, len(data))
 		blobs = append(blobs, kzg4844.Blob{})
 		copy(blobs[blobIndex][:], data[i:max])
 		blobIndex++
@@ -259,10 +256,7 @@ func EncodeBlobs(data []byte) []kzg4844.Blob {
 			blobIndex++
 			fieldIndex = 0
 		}
-		max := i + 31
-		if max > len(data) {
-			max = len(data)
-		}
+		max := min(i+31, len(data))
 		copy(blobs[blobIndex][fieldIndex*32+1:], data[i:max])
 	}
 	return blobs

--- a/ethstorage/data_shard.go
+++ b/ethstorage/data_shard.go
@@ -200,10 +200,7 @@ func (ds *DataShard) readWith(kvIdx uint64, readLen int, decoder func([]byte, ui
 			break
 		}
 
-		chunkReadLen := readLen
-		if chunkReadLen > int(ds.chunkSize) {
-			chunkReadLen = int(ds.chunkSize)
-		}
+		chunkReadLen := min(readLen, int(ds.chunkSize))
 		readLen = readLen - chunkReadLen
 
 		chunkIdx := kvIdx*ds.chunksPerKv + i

--- a/ethstorage/downloader/downloader.go
+++ b/ethstorage/downloader/downloader.go
@@ -239,10 +239,7 @@ func (s *Downloader) downloadToCache() {
 	s.mu.Unlock()
 
 	for start < end {
-		rangeEnd := start + downloadBatchSize
-		if rangeEnd > end {
-			rangeEnd = end
-		}
+		rangeEnd := min(start+downloadBatchSize, end)
 		_, err := s.downloadRange(start+1, rangeEnd, true)
 
 		if err != nil {
@@ -270,10 +267,7 @@ func (s *Downloader) download() {
 
 	for s.lastDownloadBlock < trackHead {
 		start := s.lastDownloadBlock + 1
-		end := s.lastDownloadBlock + downloadBatchSize
-		if end > trackHead {
-			end = trackHead
-		}
+		end := min(s.lastDownloadBlock+downloadBatchSize, trackHead)
 		// If downloadRange fails, then lastDownloadedBlock will keep the same as before. so when the next
 		// upload task starts, it will still try to download the blobs from the last failed block number
 		if blobs, err := s.downloadRange(start, end, false); err == nil {

--- a/ethstorage/pora/ethash/algorithm.go
+++ b/ethstorage/pora/ethash/algorithm.go
@@ -321,10 +321,7 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 			// Calculate the data segment this thread should generate
 			batch := (size + hashBytes*uint64(threads) - 1) / (hashBytes * uint64(threads))
 			first := uint64(id) * batch
-			limit := first + batch
-			if limit > size/hashBytes {
-				limit = size / hashBytes
-			}
+			limit := min(first+batch, size/hashBytes)
 			// Calculate the dataset segment
 			percent := size / hashBytes / 100
 			for index := first; index < limit; index++ {

--- a/ethstorage/shard_manager.go
+++ b/ethstorage/shard_manager.go
@@ -241,10 +241,7 @@ func (sm *ShardManager) DecodeOrEncodeKV(kvIdx uint64, b []byte, hash common.Has
 				break
 			}
 
-			chunkReadLen := datalen
-			if chunkReadLen > int(sm.chunkSize) {
-				chunkReadLen = int(sm.chunkSize)
-			}
+			chunkReadLen := min(datalen, int(sm.chunkSize))
 			datalen = datalen - chunkReadLen
 
 			chunkIdx := kvIdx*ds.chunksPerKv + i

--- a/ethstorage/storage_manager.go
+++ b/ethstorage/storage_manager.go
@@ -349,10 +349,7 @@ func (s *StorageManager) DownloadAllMetas(ctx context.Context, batchSize uint64)
 		first, limit := s.KvEntries()*sid, s.KvEntries()*(sid+1)
 
 		// batch request metas until the lastKvIdx
-		end := limit
-		if end > lastKvIdx {
-			end = lastKvIdx
-		}
+		end := min(limit, lastKvIdx)
 
 		// Additional check to ensure end is not less than first
 		// E.g. There are more than one shard, and lastKvIdx is even less than the first of the current shard
@@ -423,10 +420,7 @@ func (s *StorageManager) downloadMetaInRange(ctx context.Context, from, to, batc
 		lastKvIdx := s.lastKvIdx
 		s.mu.Unlock()
 
-		batchLimit := from + batchSize
-		if batchLimit > to {
-			batchLimit = to
-		}
+		batchLimit := min(from+batchSize, to)
 		// In case remove is supported and lastKvIndex is decreased
 		if batchLimit > lastKvIdx {
 			batchLimit = lastKvIdx


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.