### PR TITLE
Fix typo in setup commands by removing extra spaces

### DIFF
--- a/docs/archiver/archiver-guide-blob-test.md
+++ b/docs/archiver/archiver-guide-blob-test.md
@@ -52,7 +52,7 @@ git clone https://github.com/ethstorage/es-node.git
 cd es-node 
 make
 ./init-rpc.sh
-./run-rpc.sh  --l1.beacon http://localhost:3600 --archiver.enabled
+./run-rpc.sh --l1.beacon http://localhost:3600 --archiver.enabled
 ```
 
 Note: The default port for the Archive service is 9645.


### PR DESCRIPTION
This PR fixes a small formatting issue in the EthStorage Archive Service documentation. It removes extra spaces after "es-node" in the setup commands `./init-rpc.sh` and `./run-rpc.sh`, making the documentation more accurate for users following the setup instructions.