### PR TITLE
Replace deprecated 88.99.30.186 RPC

### DIFF
--- a/cmd/alert/rules.json
+++ b/cmd/alert/rules.json
@@ -4,7 +4,7 @@
     "params":{
       "name":"Sepolia Last Mined Block Alert",
       "contract":"0x804C520d3c084C805E37A35E90057Ac32831F96f",
-      "rpc":"http://88.99.30.186:8545"
+      "rpc":"http://65.108.230.142:8545"
     }
   },
   {

--- a/cmd/dashboard/config.json
+++ b/cmd/dashboard/config.json
@@ -2,7 +2,7 @@
   {
     "name":"Sepolia",
     "type": "l1",
-    "rpc":"http://88.99.30.186:8545",
+    "rpc":"http://65.108.230.142:8545",
     "chainID": 3333,
     "contract":"0x804C520d3c084C805E37A35E90057Ac32831F96f",
     "startNumber": 5528000

--- a/docs/archiver/archiver-guide-blob-test.md
+++ b/docs/archiver/archiver-guide-blob-test.md
@@ -36,7 +36,7 @@ To download and run a proxy for the Beacon client, execute the following command
 ```bash
 git clone https://github.com/ethstorage/beacon-api-wrapper.git
 cd beacon-api-wrapper
-go run cmd/main.go -r 3 -b http://88.99.30.186:3500
+go run cmd/main.go -r 3 -b http://65.108.230.142:3500
 ```
 
 This proxy functions like a standard Beacon API, except that it has a much shorter blob retention period - 3 epochs or 96 slots in this case. Consequently, when a `blob_sidecars` request is made for blobs older than this time frame, it will return an empty list: `{"data":[]}`.
@@ -64,8 +64,8 @@ For additional details and options for running an es-node, please refer to the [
 Set the following environment variables for later use:
 
 ```bash
-export RPC_URL="http://88.99.30.186:8545"
-export BEACON_API="http://88.99.30.186:3500"
+export RPC_URL="http://65.108.230.142:8545"
+export BEACON_API="http://65.108.230.142:3500"
 export BEACON_API_MOCK="http://localhost:3600"
 export ARCHIVE_SERVICE="http://65.108.236.27:9645"
 ```

--- a/docs/archiver/archiver-guide-sepolia.md
+++ b/docs/archiver/archiver-guide-sepolia.md
@@ -164,8 +164,8 @@ To start the op-node, execute the following command:
   --rpc.addr=0.0.0.0 \
   --rpc.port=9595 \
   --rpc.enable-admin \
-  --l1=http://88.99.30.186:8545 \
-  --l1.beacon=http://88.99.30.186:3500 \
+  --l1=http://65.108.230.142:8545 \
+  --l1.beacon=http://65.108.230.142:3500 \
   --l1.rpckind=basic \
   --l1.beacon-archiver=http://65.108.236.27:9645
 ```

--- a/docs/archiver/archiver-spec.md
+++ b/docs/archiver/archiver-spec.md
@@ -6,7 +6,7 @@ Es-node Archiver Specification
 1. As a long-term data availability solution for rollups, the es-node archiver will serve as a fallback source of blob sidecars besides Ethereum Layer 1.  
 2. The way to provide blob is the same as the [getBlobSidecars beacon API](https://ethereum.github.io/beacon-APIs/#/Beacon/getBlobSidecars)  beacon API `/eth/v1/beacon/blob_sidecars/{block_id}`, where you can provide `block_id` in path and `indices` as a query string to download blob sidecars as an array in json format. A live example:
 ```sh
-curl -X 'GET'   'http://88.99.30.186:3500/eth/v1/beacon/blob_sidecars/4700280?indices=0,2'   -H 'accept: application/json' 
+curl -X 'GET'   'http://65.108.230.142:3500/eth/v1/beacon/blob_sidecars/4700280?indices=0,2'   -H 'accept: application/json' 
 ```
  
 3. The difference in returned data between es-node archiver API and beacon API is that for each blob es-node archiver only returns blob content, index, kzg commitment, and kzg proof. Other elements will be omitted according to how Optimism uses the service.

--- a/init.sh
+++ b/init.sh
@@ -118,7 +118,7 @@ fi
 
 es_node_init="$executable init $shards \
   --datadir $data_dir \
-  --l1.rpc http://88.99.30.186:8545 \
+  --l1.rpc http://65.108.230.142:8545 \
   --storage.l1contract 0x804C520d3c084C805E37A35E90057Ac32831F96f \
 $remaining_args"
 

--- a/integration_tests/archiver_test.go
+++ b/integration_tests/archiver_test.go
@@ -20,7 +20,7 @@ import (
 const (
 	urlPattern   = "http://%s/eth/v1/beacon/blob_sidecars/%s"
 	archiverAddr = "65.108.236.27:9645"
-	beaconAddr   = "88.99.30.186:3500"
+	beaconAddr   = "65.108.230.142:3500"
 )
 
 type test struct {

--- a/integration_tests/run_tests.sh
+++ b/integration_tests/run_tests.sh
@@ -42,7 +42,7 @@ if [ -z "$ES_NODE_CLEF_RPC" ]; then
 fi
 
 if [ -z "$ES_NODE_RANDAO_RPC" ]; then
-  export ES_NODE_RANDAO_RPC="http://88.99.30.186:8545"
+  export ES_NODE_RANDAO_RPC="http://65.108.230.142:8545"
 fi
 
 echo ES_NODE_L1_ETH_RPC = $ES_NODE_L1_ETH_RPC
@@ -57,4 +57,3 @@ if [ ! -e  ${zkey_file} ]; then
 fi
 
 go test -tags rapidsnark_asm  -run ^TestMining$ -timeout 0 github.com/ethstorage/go-ethstorage/integration_tests -v -count=1
- 

--- a/run-l2-it-rpc.sh
+++ b/run-l2-it-rpc.sh
@@ -30,7 +30,7 @@ exec ./build/bin/es-node \
   --l1.block_time 2 \
   --l1.rpc http://5.9.87.214:8545 \
   --da.url http://5.9.87.214:8888 \
-  --randao.url http://88.99.30.186:8545 \
+  --randao.url http://65.108.230.142:8545 \
   --rpc.port 9595 \
   --p2p.listen.udp 30395 \
   --p2p.listen.tcp 9295 \

--- a/run-l2-it.sh
+++ b/run-l2-it.sh
@@ -28,7 +28,7 @@ exec ./build/bin/es-node \
   --l1.block_time 2 \
   --l1.rpc http://5.9.87.214:8545 \
   --da.url http://5.9.87.214:8888 \
-  --randao.url http://88.99.30.186:8545 \
+  --randao.url http://65.108.230.142:8545 \
   --state.upload.url http://127.0.0.1:9096 \
   --rpc.port 9596 \
   --p2p.listen.udp 30396 \

--- a/run-l2.sh
+++ b/run-l2.sh
@@ -6,6 +6,6 @@
   --l1.block_time 2 \
   --l2.chain_id 3337 \
   --da.url http://5.9.87.214:8888 \
-  --randao.url http://88.99.30.186:8545 \
+  --randao.url http://65.108.230.142:8545 \
   --p2p.bootnodes enr:-Lq4QEXYjk9uxm2_r-JXoXnpqMu54YIIrTFYd7sfQKAgFQL1fiq4mkUHGkV6mIas6sh7klavj5z6sFZYRfvtldSq6LOGAZb2MuHbimV0aHN0b3JhZ2Xdgg0JgNjXlGQAOtvfMBT344_GvnUusEe5XaiawYCCaWSCdjSCaXCEisl6PYlzZWNwMjU2azGhAgsmoUh0dDjPTG5kiyxCDwG5VNK_d1WCSJ4KkVJ6-57zg3RjcIIkBoN1ZHCCdmE \
  $@

--- a/run.sh
+++ b/run.sh
@@ -29,8 +29,8 @@ start_flags=" --network devnet \
   --datadir $data_dir \
   $file_flags \
   --storage.l1contract 0x804C520d3c084C805E37A35E90057Ac32831F96f \
-  --l1.rpc http://88.99.30.186:8545 \
-  --l1.beacon http://88.99.30.186:3500 \
+  --l1.rpc http://65.108.230.142:8545 \
+  --l1.beacon http://65.108.230.142:3500 \
   --miner.enabled \
   --miner.zkey $zkey_file \
   --download.thread 32 \

--- a/sync-l2.sh
+++ b/sync-l2.sh
@@ -6,5 +6,5 @@
 ./sync.sh \
   --storage.l1contract 0x64003adbdf3014f7E38FC6BE752EB047b95da89A \
   --l1.rpc http://5.9.87.214:8545 \
-  --es_rpc http://65.109.115.36:9596 \
+  --es_rpc http://65.108.230.142:9596 \
 $@

--- a/sync.sh
+++ b/sync.sh
@@ -17,8 +17,8 @@ start_flags=" sync \
   --datadir $data_dir \
   $file_flags \
   --storage.l1contract 0x804C520d3c084C805E37A35E90057Ac32831F96f \
-  --l1.rpc http://88.99.30.186:8545 \
-  --es_rpc http://65.108.236.27:9540 \
+  --l1.rpc http://65.108.230.142:8545 \
+  --es_rpc http://65.108.230.142:9545 \
   $@"
 
 exec $executable $start_flags


### PR DESCRIPTION
This PR updates the RPC endpoint from the deprecated 88.99.30.186 address to the latest supported RPC.
The previous endpoint is scheduled to be shut down and will no longer be available.
This change ensures continued functionality and network connectivity.