### PR TITLE
check miner role

### DIFF
--- a/ethstorage/eth/polling_client.go
+++ b/ethstorage/eth/polling_client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
+	"golang.org/x/mod/semver"
 )
 
 const (
@@ -331,4 +332,32 @@ func (w *PollingClient) ReadContractField(fieldName string, blockNumber *big.Int
 		return nil, fmt.Errorf("failed to get %s from contract: %v", fieldName, err)
 	}
 	return bs, nil
+}
+
+func (w *PollingClient) GetContractVersion() (string, error) {
+	bs, err := w.ReadContractField("version", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to get version from contract: %v", err)
+	}
+	versionStr, err := decodeString(bs)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode version string: %v", err)
+	}
+	version := "v" + versionStr
+	if !semver.IsValid(version) {
+		return "", fmt.Errorf("invalid version string: %s", versionStr)
+	}
+	return version, nil
+}
+
+func decodeString(data []byte) (string, error) {
+	if len(data) < 64 {
+		return "", fmt.Errorf("data too short")
+	}
+	strLen := new(big.Int).SetBytes(data[32:64]).Int64()
+	if int64(len(data)) < 64+strLen {
+		return "", fmt.Errorf("data length mismatch")
+	}
+	strBytes := data[64 : 64+strLen]
+	return string(strBytes), nil
 }

--- a/ethstorage/miner/l1_mining_api.go
+++ b/ethstorage/miner/l1_mining_api.go
@@ -42,6 +42,7 @@ type l1MiningAPI struct {
 	lg log.Logger
 }
 
+// Pre-check if the miner has been whitelisted before actually mining
 func (m *l1MiningAPI) CheckMinerRole(ctx context.Context, contract, miner common.Address) error {
 	enforced, err := m.PollingClient.ReadContractField("enforceMinerRole", nil)
 	if err != nil {
@@ -63,7 +64,7 @@ func (m *l1MiningAPI) CheckMinerRole(ctx context.Context, contract, miner common
 			m.lg.Info("Miner role granted", "miner", miner)
 			return nil
 		}
-		return fmt.Errorf("miner role not granted: %s", miner)
+		return fmt.Errorf("miner role not granted to: %s", miner)
 	}
 	m.lg.Info("Miner role not enforced")
 	return nil

--- a/ethstorage/node/node.go
+++ b/ethstorage/node/node.go
@@ -309,8 +309,7 @@ func (n *EsNode) initMiner(ctx context.Context, cfg *Config) error {
 		return nil
 	}
 	l1api := miner.NewL1MiningAPI(n.l1Source, n.randaoSource, n.log)
-	err := l1api.CheckMinerRole(ctx, cfg.Storage.L1Contract, cfg.Storage.Miner)
-	if err != nil {
+	if err := l1api.CheckMinerRole(ctx, cfg.Storage.L1Contract, cfg.Storage.Miner); err != nil {
 		n.log.Crit("Check miner role", "err", err)
 	}
 	pvr := prover.NewKZGPoseidonProver(

--- a/ethstorage/node/node.go
+++ b/ethstorage/node/node.go
@@ -309,6 +309,10 @@ func (n *EsNode) initMiner(ctx context.Context, cfg *Config) error {
 		return nil
 	}
 	l1api := miner.NewL1MiningAPI(n.l1Source, n.randaoSource, n.log)
+	err := l1api.CheckMinerRole(ctx, cfg.Storage.L1Contract, cfg.Storage.Miner)
+	if err != nil {
+		n.log.Crit("Check miner role", "err", err)
+	}
 	pvr := prover.NewKZGPoseidonProver(
 		cfg.Mining.ZKWorkingDir,
 		cfg.Mining.ZKeyFile,


### PR DESCRIPTION
Check if the miner is in the miner's role (whitelisted) when es-node is started.

Tests have been done when starting es-node:

Based on storage contract version:

**v0.1.1**
ignore role check

**v0.1.2**
Happy paths:
-  Miner role enforced / Miner role granted
-  Miner role not enforced

Failed to start es-node:
-  Miner role enforced / Miner role not granted
