### PR TITLE
add 'Set Miner To Whitelist' to integration test workflow

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -53,6 +53,10 @@ jobs:
           echo ES_NODE_SIGNER_PRIVATE_KEY=`cat ../private.key` >> "$GITHUB_ENV"
           echo ES_NODE_STORAGE_MINER=0x5C935469C5592Aeeac3372e922d9bCEabDF8830d >> "$GITHUB_ENV"
 
+      - name: Set Miner To Whitelist
+        run: |
+          cast send -r 'http://5.9.87.214:8545' --private-key $ES_NODE_SIGNER_PRIVATE_KEY $ES_NODE_CONTRACT_ADDRESS "grantMinerRole(address)" $ES_NODE_STORAGE_MINER
+
       - name: Upload Blobs
         run: |
           cd ./integration_tests/scripts 


### PR DESCRIPTION
integration test fail (https://github.com/ethstorage/es-node/actions/runs/15994097861/job/45113399279) as our contract updated and added miner whitelisted to contract, so our integration test need to add 'Set Miner To Whitelist' step to action workflow.

Error message:
```
INFO [07-02|11:36:45.551] Suggested gas fee cap                    gasFeeCap=1,000,251
INFO [07-02|11:36:45.582] Sampling done with all nonces            samplingTime=0.4s shard=0 block=8,675,208
ERROR[07-02|11:36:45.609] Estimate gas failed                      error="execution reverted: StorageContract: miner not whitelisted"
ERROR[07-02|11:36:45.609] Failed to submit mined result            shard=0 block=8,675,206 error="failed to estimate gas: execution reverted: StorageContract: miner not whitelisted"
INFO [07-02|11:36:49.914] Don't find blob in the cache, will try to download directly blockNumber=8,296,253 start=8,296,253 end=8,296,253 toCache=true
```