### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/ethstorage/p2p/protocol/syncclient.go
+++ b/ethstorage/p2p/protocol/syncclient.go
@@ -232,10 +232,7 @@ func NewSyncClient(log log.Logger, cfg *rollup.EsConfig, newStream newStreamFn, 
 }
 
 func getMinPeersPerShard(maxPeers, shardCount int) int {
-	minPeersPerShard := (maxPeers + shardCount - 1) / shardCount
-	if minPeersPerShard < defaultMinPeersPerShard {
-		minPeersPerShard = defaultMinPeersPerShard
-	}
+	minPeersPerShard := max((maxPeers+shardCount-1)/shardCount, defaultMinPeersPerShard)
 	return minPeersPerShard
 }
 
@@ -363,16 +360,10 @@ func (s *SyncClient) createTask(sid uint64, lastKvIndex uint64) *task {
 	subTasks := make([]*subTask, 0)
 	// split subTask for a shard to 16 subtasks and if one batch is too small
 	// set to minSubTaskSize
-	maxTaskSize := (limit - first + s.syncerParams.SyncConcurrency - 1) / s.syncerParams.SyncConcurrency
-	if maxTaskSize < minSubTaskSize {
-		maxTaskSize = minSubTaskSize
-	}
+	maxTaskSize := max((limit-first+s.syncerParams.SyncConcurrency-1)/s.syncerParams.SyncConcurrency, minSubTaskSize)
 
 	for first < limit {
-		last := first + maxTaskSize
-		if last > limit {
-			last = limit
-		}
+		last := min(first+maxTaskSize, limit)
 		subTask := subTask{
 			task:  &task,
 			next:  first,
@@ -388,16 +379,10 @@ func (s *SyncClient) createTask(sid uint64, lastKvIndex uint64) *task {
 	subEmptyTasks := make([]*subEmptyTask, 0)
 	if limitForEmpty > 0 {
 		task.state.EmptyToFill = limitForEmpty - firstEmpty
-		maxEmptyTaskSize := (limitForEmpty - firstEmpty + uint64(maxFillEmptyTaskTreads) - 1) / uint64(maxFillEmptyTaskTreads)
-		if maxEmptyTaskSize < minSubTaskSize {
-			maxEmptyTaskSize = minSubTaskSize
-		}
+		maxEmptyTaskSize := max((limitForEmpty-firstEmpty+uint64(maxFillEmptyTaskTreads)-1)/uint64(maxFillEmptyTaskTreads), minSubTaskSize)
 
 		for firstEmpty < limitForEmpty {
-			last := firstEmpty + maxEmptyTaskSize
-			if last > limitForEmpty {
-				last = limitForEmpty
-			}
+			last := min(firstEmpty+maxEmptyTaskSize, limitForEmpty)
 			subTask := subEmptyTask{
 				task:  &task,
 				First: firstEmpty,
@@ -759,10 +744,7 @@ func (s *SyncClient) assignBlobRangeTasks() {
 				continue
 			}
 
-			last := st.next + maxRange
-			if last > st.Last {
-				last = st.Last
-			}
+			last := min(st.next+maxRange, st.Last)
 			req := &blobsByRangeRequest{
 				peer:     pr.ID(),
 				id:       rand.Uint64(),

--- a/ethstorage/prover/merkleprover.go
+++ b/ethstorage/prover/merkleprover.go
@@ -27,10 +27,7 @@ func (MerkleProver) GetProof(data []byte, nChunkBits, chunkIdx, chunkSize uint64
 		if off > uint64(len(data)) {
 			break
 		}
-		l := uint64(len(data)) - off
-		if l >= chunkSize {
-			l = chunkSize
-		}
+		l := min(uint64(len(data))-off, chunkSize)
 		nodes[i] = crypto.Keccak256Hash(data[off : off+l])
 	}
 	n, proofIdx := nChunks, uint64(0)
@@ -79,10 +76,7 @@ func (MerkleProver) GetRoot(data []byte, chunkPerKV, chunkSize uint64) common.Ha
 			// empty mean the leaf is zero
 			break
 		}
-		size := l - off
-		if size >= chunkSize {
-			size = chunkSize
-		}
+		size := min(l-off, chunkSize)
 		hash := crypto.Keccak256Hash(data[off : off+size])
 		nodes[i] = hash
 	}

--- a/ethstorage/scanner/worker.go
+++ b/ethstorage/scanner/worker.go
@@ -175,10 +175,7 @@ func getKvsInBatch(shards []uint64, kvEntries, lastKvIdx, batchSize, batchStartI
 		startKvIndex = 0
 		lg.Info("Scanner: restarting scan from beginning")
 	}
-	endKvIndexExclusive := startKvIndex + batchSize
-	if endKvIndexExclusive > totalEntries {
-		endKvIndexExclusive = totalEntries
-	}
+	endKvIndexExclusive := min(startKvIndex+batchSize, totalEntries)
 	// The actual batch would be [startKvIndex, endKvIndexExclusive) or [startKvIndex, endIndex]
 	endIndex := endKvIndexExclusive - 1
 

--- a/ethstorage/storage_manager.go
+++ b/ethstorage/storage_manager.go
@@ -455,11 +455,8 @@ func (s *StorageManager) downloadMetaInRange(ctx context.Context, from, to, batc
 		kvEntryCount := s.kvEntryCount
 		s.mu.Unlock()
 
-		batchLimit := min(from+batchSize, to)
 		// In case remove is supported and kvEntryCount is decreased
-		if batchLimit > kvEntryCount {
-			batchLimit = kvEntryCount
-		}
+		batchLimit := min(min(from+batchSize, to), kvEntryCount)
 
 		kvIndices := []uint64{}
 		for i := from; i < batchLimit; i++ {


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

Inspired by https://github.com/ethstorage/es-node/pull/396 and I replace all of the case.