### PR TITLE
Fix Windows build failure: go-rapidsnark prover does not support Windows

### DIFF
--- a/ethstorage/prover/zk_prover_go.go
+++ b/ethstorage/prover/zk_prover_go.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Copyright 2022-2023, EthStorage.
 // For license information, see https://github.com/ethstorage/es-node/blob/main/LICENSE
 

--- a/ethstorage/prover/zk_prover_go_windows.go
+++ b/ethstorage/prover/zk_prover_go_windows.go
@@ -1,0 +1,42 @@
+//go:build windows
+
+// Copyright 2022-2023, EthStorage.
+// For license information, see https://github.com/ethstorage/es-node/blob/main/LICENSE
+
+package prover
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"math/big"
+	"sync"
+)
+
+type ZKProverGo struct {
+	zkey []byte
+	wasm []byte
+	lg   log.Logger
+	mu   sync.Mutex
+}
+
+// Singleton with a lock is used as RapidsNARK may not be thread-safe at the C++ level.
+func NewZKProverGo(libDir, zkeyFile, wasmName string, lg log.Logger) (*ZKProverGo, error) {
+	panic("go-rapidsnark do not support windows")
+}
+
+// Generate ZK Proof for the given encoding key and sample index
+func (p *ZKProverGo) GenerateZKProof(encodingKeys []common.Hash, sampleIdxs []uint64) ([]byte, []*big.Int, error) {
+	panic("go-rapidsnark do not support windows")
+}
+
+func (p *ZKProverGo) GenerateZKProofRaw(encodingKeys []common.Hash, sampleIdxs []uint64) ([]byte, []*big.Int, error) {
+	panic("go-rapidsnark do not support windows")
+}
+
+func (p *ZKProverGo) GenerateZKProofPerSample(encodingKey common.Hash, sampleIdx uint64) ([]byte, *big.Int, error) {
+	panic("go-rapidsnark do not support windows")
+}
+
+func (p *ZKProverGo) prove(inputBytes []byte) ([]byte, string, error) {
+	panic("go-rapidsnark do not support windows")
+}


### PR DESCRIPTION
Currently, running go build on Windows results in an error because our zk_prover_go.go depends on github.com/iden3/go-rapidsnark/prover@v0.0.12, which does not support Windows.
```
go build
package github.com/ethstorage/go-ethstorage/cmd/es-node
        imports github.com/ethstorage/go-ethstorage/ethstorage/email
        imports github.com/ethstorage/go-ethstorage/ethstorage/p2p
        imports github.com/ethstorage/go-ethstorage/ethstorage/p2p/protocol
        imports github.com/ethstorage/go-ethstorage/ethstorage/prover
        imports github.com/iden3/go-rapidsnark/prover: build constraints exclude all Go files in C:\Users\molao\go\pkg\mod\github.com\iden3\go-rapidsnark\prover@v0.0.12
```

This change adds a Windows-specific implementation zk_prover_go_windows.go to enable building es-node on Windows.