### PR TITLE
keep scanner stats up todate

### DIFF
--- a/ethstorage/scanner/scanner.go
+++ b/ethstorage/scanner/scanner.go
@@ -115,6 +115,10 @@ func (s *Scanner) start() {
 				s.lg.Debug("Scanner: executing scheduled scan")
 				s.doWork(sts.mismatched.clone())
 
+				// Update the latest stats after each scan immediately
+				st := <-s.statsCh
+				sts = &st
+
 			case <-reportTicker.C:
 				if statsUpdated { // Wait for stats updated for the first time
 					s.logStats(sts)


### PR DESCRIPTION
**Issue Description**

Notice in the following logs at `09-24|10:21:42.508`, blob fixed successfully on kvIndex=18, but the stats log does not reflact the change immediately until next stats report.

```log
INFO [09-24|10:18:40.699] Scanner started                          mode=2 interval=3m0s batchSize=100
INFO [09-24|10:18:40.699] Scanner: local storage info              lastKvIdx=23 shards="[0 1 2]" kvEntriesPerShard=8
WARN [09-24|10:18:43.321] Scanner: commit mismatch detected        kvIndex=17 error="commit mismatch: expected=018eb161d137ff6dab9649a7cf5f3f1ec6e18dd4f68983cc, found=01bc9630e13e4f0c95cb24bf4e54d19bf0a89aad909c9d36"
INFO [09-24|10:18:43.321] Scanner: first-time mismatch, skipping fix attempt kvIndex=17
WARN [09-24|10:18:43.374] Scanner: commit mismatch detected        kvIndex=18 error="commit mismatch: expected=015f68c3f9c1594864e5d10e940cad2facc85ed121aaebb2, found=011e4908312a677565712fdcc579a7875d889cc9b30f5264"
INFO [09-24|10:18:43.374] Scanner: first-time mismatch, skipping fix attempt kvIndex=18
INFO [09-24|10:18:43.954] Scanner: scan batch done                 scanned=[0-23] count=24 nextIndexOfKvIdx=24
INFO [09-24|10:18:43.954] Scan batch done                          duration=3.25525506s
INFO [09-24|10:19:40.081] P2P Summary                              activePeers=1 inbound=0 outbound=1
INFO [09-24|10:19:40.698] Scanner stats                            localKvs=shard0[0-7],shard1[8-15],shard2[16-23] localKvsCount=24 mismatched=[17(pending),18(pending)]
INFO [09-24|10:20:40.083] P2P Summary                              activePeers=1 inbound=0 outbound=1
INFO [09-24|10:20:40.698] Scanner stats                            localKvs=shard0[0-7],shard1[8-15],shard2[16-23] localKvsCount=24 mismatched=[17(pending),18(pending)]
INFO [09-24|10:21:22.953] Don't find blob in the cache, will try to download directly blockNumber=11,879,371 start=11,879,309 end=11,879,372 toCache=false
INFO [09-24|10:21:31.196] Downloaded and encoded                   blockNumber=11,879,371 kvIdx=17
INFO [09-24|10:21:31.196] Download range                           cache=false start=11,879,309 end=11,879,372 blobNumber=1 duration(ms)=9792
INFO [09-24|10:21:31.196] Blob will be saved into disk             kvIndex=17 hash=018eb161d137ff6dab9649a7cf5f3f1ec6e18dd4f68983cc3d736f08881a45b6
INFO [09-24|10:21:31.463] DownloadFinished                         duration(ms)=267  blobs=1
INFO [09-24|10:21:31.993] Don't find blob in the cache, will try to download directly blockNumber=11,879,382 start=11,879,373 end=11,879,436 toCache=false
INFO [09-24|10:21:40.080] P2P Summary                              activePeers=1 inbound=0 outbound=1
INFO [09-24|10:21:40.696] Scanner: local storage info              lastKvIdx=23 shards="[0 1 2]" kvEntriesPerShard=8
INFO [09-24|10:21:41.845] Scanner: previously pending KV recovered kvIndex=17
WARN [09-24|10:21:41.915] Scanner: commit mismatch detected        kvIndex=18 error="commit mismatch: expected=015f68c3f9c1594864e5d10e940cad2facc85ed121aaebb2, found=011e4908312a677565712fdcc579a7875d889cc9b30f5264"
INFO [09-24|10:21:41.915] Scanner: mismatch again, attempting to fix blob kvIndex=18 commit=015f68..000000
INFO [09-24|10:21:42.241] Scanner: blob fixed successfully         kvIndex=18
INFO [09-24|10:21:42.508] Scanner: scan batch done                 scanned=[0-23] count=24 nextIndexOfKvIdx=24
INFO [09-24|10:21:42.508] Scan batch done                          duration=1.812151268s
INFO [09-24|10:21:42.508] Scanner stats                            localKvs=shard0[0-7],shard1[8-15],shard2[16-23] localKvsCount=24 mismatched=[17(pending),18(pending)]
INFO [09-24|10:21:42.785] Downloaded and encoded                   blockNumber=11,879,382 kvIdx=18
INFO [09-24|10:21:42.785] Download range                           cache=false start=11,879,373 end=11,879,436 blobNumber=1 duration(ms)=11321
INFO [09-24|10:21:42.785] Blob will be saved into disk             kvIndex=18 hash=015f68c3f9c1594864e5d10e940cad2facc85ed121aaebb21f261498b42cd037
INFO [09-24|10:21:43.057] DownloadFinished                         duration(ms)=271   blobs=1
INFO [09-24|10:22:40.079] P2P Summary                              activePeers=1 inbound=0 outbound=1
INFO [09-24|10:22:40.696] Scanner stats                            localKvs=shard0[0-7],shard1[8-15],shard2[16-23] localKvsCount=24 mismatched=[18(fixed)]
```

After this PR fix, the stats log is up to date.

```log

INFO [09-24|15:56:51.502] Scanner started                          mode=2 interval=3m0s batchSize=100
INFO [09-24|15:56:51.502] Scanner: local storage info              lastKvIdx=23 shards="[0 1 2]" kvEntriesPerShard=8
WARN [09-24|15:56:53.285] Scanner: commit mismatch detected        kvIndex=16 error="commit mismatch: expected=01b29f4785bf330747e8e8079d5fdb6d613c8e1fb4bc873f, found=01075a58e7276b6b7a869be31508d46ce8f38e2deebd4f23"
INFO [09-24|15:56:53.285] Scanner: first-time mismatch, skipping fix attempt kvIndex=16
WARN [09-24|15:56:53.650] Scanner: commit mismatch detected        kvIndex=17 error="commit mismatch: expected=018eb161d137ff6dab9649a7cf5f3f1ec6e18dd4f68983cc, found=01bc9630e13e4f0c95cb24bf4e54d19bf0a89aad909c9d36"
INFO [09-24|15:56:53.650] Scanner: first-time mismatch, skipping fix attempt kvIndex=17
WARN [09-24|15:56:53.709] Scanner: commit mismatch detected        kvIndex=18 error="commit mismatch: expected=015f68c3f9c1594864e5d10e940cad2facc85ed121aaebb2, found=011e4908312a677565712fdcc579a7875d889cc9b30f5264"
INFO [09-24|15:56:53.709] Scanner: first-time mismatch, skipping fix attempt kvIndex=18
INFO [09-24|15:56:53.953] Scanner: scan batch done                 scanned=[0-23] count=24 nextIndexOfKvIdx=24
INFO [09-24|15:56:53.953] Scan batch done                          duration=2.450993015s
INFO [09-24|15:57:50.878] P2P Summary                              activePeers=1 inbound=1 outbound=0
INFO [09-24|15:57:51.503] Scanner stats                            localKvs=shard0[0-7],shard1[8-15],shard2[16-23] localKvsCount=24 mismatched=[16(pending),17(pending),18(pending)]
INFO [09-24|15:57:52.585] Don't find blob in the cache, will try to download directly blockNumber=11,825,535 start=11,825,504 end=11,825,567 toCache=false
INFO [09-24|15:58:06.501] Downloaded and encoded                   blockNumber=11,825,535 kvIdx=16
INFO [09-24|15:58:06.501] Download range                           cache=false start=11,825,504 end=11,825,567 blobNumber=1 duration(ms)=14544
INFO [09-24|15:58:06.501] Blob will be saved into disk             kvIndex=16 hash=01b29f4785bf330747e8e8079d5fdb6d613c8e1fb4bc873f6235ec3bb1ac0c6b
INFO [09-24|15:58:06.773] DownloadFinished                         duration(ms)=272   blobs=1
INFO [09-24|15:58:50.879] P2P Summary                              activePeers=1 inbound=1 outbound=0
INFO [09-24|15:58:51.505] Scanner stats                            localKvs=shard0[0-7],shard1[8-15],shard2[16-23] localKvsCount=24 mismatched=[16(pending),17(pending),18(pending)]
INFO [09-24|15:59:50.881] P2P Summary                              activePeers=1 inbound=1 outbound=0
INFO [09-24|15:59:51.508] Scanner: local storage info              lastKvIdx=23 shards="[0 1 2]" kvEntriesPerShard=8
INFO [09-24|15:59:53.495] Scanner: previously pending KV recovered kvIndex=16
WARN [09-24|15:59:53.541] Scanner: commit mismatch detected        kvIndex=17 error="commit mismatch: expected=018eb161d137ff6dab9649a7cf5f3f1ec6e18dd4f68983cc, found=01bc9630e13e4f0c95cb24bf4e54d19bf0a89aad909c9d36"
INFO [09-24|15:59:53.541] Scanner: mismatch again, attempting to fix blob kvIndex=17 commit=018eb1..000000
INFO [09-24|15:59:54.599] Scanner: blob fixed successfully         kvIndex=17
WARN [09-24|15:59:54.651] Scanner: commit mismatch detected        kvIndex=18 error="commit mismatch: expected=015f68c3f9c1594864e5d10e940cad2facc85ed121aaebb2, found=011e4908312a677565712fdcc579a7875d889cc9b30f5264"
INFO [09-24|15:59:54.651] Scanner: mismatch again, attempting to fix blob kvIndex=18 commit=015f68..000000
INFO [09-24|15:59:55.752] Scanner: blob fixed successfully         kvIndex=18
INFO [09-24|15:59:56.345] Scanner: scan batch done                 scanned=[0-23] count=24 nextIndexOfKvIdx=24
INFO [09-24|15:59:56.345] Scan batch done                          duration=4.836814301s
INFO [09-24|15:59:56.345] Scanner stats                            localKvs=shard0[0-7],shard1[8-15],shard2[16-23] localKvsCount=24 mismatched=[17(fixed),18(fixed)]
```