### PR TITLE
chore: fix function name mismatch in comment for blobsHandler

### DIFF
--- a/ethstorage/archiver/service.go
+++ b/ethstorage/archiver/service.go
@@ -73,7 +73,7 @@ func (a *APIService) blobSidecarHandler(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-// blobSidecarHandler implements the /eth/v1/beacon/blobs/{id} endpoint
+// blobsHandler implements the /eth/v1/beacon/blobs/{id} endpoint
 func (a *APIService) blobsHandler(w http.ResponseWriter, r *http.Request) {
 
 	a.lg.Info("Blob archiver API request", "from", readUserIP(r), "url", r.RequestURI)


### PR DESCRIPTION

Corrected the comment for the `blobsHandler` function in `service.go`   to accurately reflect the function name. The comment previously incorrectly referred to `blobSidecarHandler` instead of `blobsHandler`, which could cause confusion during code review or maintenance. 

This change ensures the documentation matches the implementation, improving code clarity and maintainability.