### PR TITLE
Fix `FailedToObtainBlockhash` in case of empty slots 

### DIFF
--- a/ethstorage/miner/worker.go
+++ b/ethstorage/miner/worker.go
@@ -115,8 +115,7 @@ type worker struct {
 	db         ethdb.Database
 	storageMgr *es.StorageManager
 
-	latestL1Head uint64
-	headUpdateCh chan struct{}
+	headUpdateCh chan uint64
 
 	chainHeadCh chan eth.L1BlockRef
 	startCh     chan uint64
@@ -158,7 +157,7 @@ func newWorker(
 		dataReader:       dr,
 		prover:           prover,
 		chainHeadCh:      chainHeadCh,
-		headUpdateCh:     make(chan struct{}, 1),
+		headUpdateCh:     make(chan uint64, 1),
 		shardTaskMap:     make(map[uint64]task),
 		exitCh:           make(chan struct{}),
 		startCh:          make(chan uint64, 1),
@@ -185,27 +184,6 @@ func newWorker(
 	go worker.newWorkLoop()
 	go worker.resultLoop()
 	return worker
-}
-
-func (w *worker) updateLatestL1Head(incoming uint64) {
-	for {
-		current := atomic.LoadUint64(&w.latestL1Head)
-		if incoming <= current {
-			w.lg.Info("L1 head is already updated", "current", current, "incoming", incoming)
-			return
-		}
-		if atomic.CompareAndSwapUint64(&w.latestL1Head, current, incoming) {
-			w.lg.Info("Latest L1 head updated", "current", current, "incoming", incoming)
-			select {
-			case w.headUpdateCh <- struct{}{}:
-				w.lg.Info("headUpdateCh notified", "current", current, "incoming", incoming)
-			default:
-				w.lg.Info("headUpdateCh notification skipped to avoid blocking", "current", current, "incoming", incoming)
-			}
-			return
-		}
-		w.lg.Info("Concurrent L1 head update detected, retrying", "current", current, "incoming", incoming)
-	}
 }
 
 func (w *worker) start() {
@@ -318,6 +296,20 @@ func (w *worker) newWorkLoop() {
 		case <-w.exitCh:
 			w.lg.Warn("Worker is exiting from work loop...")
 			return
+		}
+	}
+}
+
+func (w *worker) updateLatestL1Head(new uint64) {
+	for {
+		select {
+		case w.headUpdateCh <- new:
+			return
+		case old := <-w.headUpdateCh:
+			// Keep monotonic block height while replacing buffered value.
+			if old > new {
+				new = old
+			}
 		}
 	}
 }
@@ -436,28 +428,6 @@ func (w *worker) notifyResultLoop() {
 	}
 }
 
-// waitUntilBlockAdvanced waits until L1 head is strictly newer than the mined block.
-func (w *worker) waitUntilBlockAdvanced(mined uint64) bool {
-	loggedWaiting := false
-	for {
-		latest := atomic.LoadUint64(&w.latestL1Head)
-		if latest > mined {
-			w.lg.Info("L1 head advanced since mined block", "mined", mined, "latest", latest)
-			return true
-		}
-		if !loggedWaiting {
-			w.lg.Info("Hold on submitting mining result until L1 head advances", "mined", mined, "latest", latest)
-			loggedWaiting = true
-		}
-		select {
-		case <-w.headUpdateCh:
-			w.lg.Info("L1 head update received", "mined", mined, "latest", atomic.LoadUint64(&w.latestL1Head))
-		case <-w.exitCh:
-			return false
-		}
-	}
-}
-
 // resultLoop is a standalone goroutine to submit mining result to L1 contract.
 func (w *worker) resultLoop() {
 	defer w.wg.Done()
@@ -546,6 +516,22 @@ func (w *worker) resultLoop() {
 				w.lg.Error("Mining error since es-node launched", "err", e)
 			}
 			return
+		}
+	}
+}
+
+// waitUntilBlockAdvanced waits until L1 head is strictly newer than the mined block.
+func (w *worker) waitUntilBlockAdvanced(mined uint64) bool {
+	for {
+		select {
+		case latest := <-w.headUpdateCh:
+			if latest > mined {
+				w.lg.Info("L1 head advanced since mined block", "mined", mined, "latest", latest)
+				return true
+			}
+			w.lg.Info("L1 head not advanced since mined block, keep waiting", "mined", mined, "latest", latest)
+		case <-w.exitCh:
+			return false
 		}
 	}
 }

--- a/ethstorage/miner/worker.go
+++ b/ethstorage/miner/worker.go
@@ -115,6 +115,9 @@ type worker struct {
 	db         ethdb.Database
 	storageMgr *es.StorageManager
 
+	latestL1Head uint64
+	headUpdateCh chan struct{}
+
 	chainHeadCh chan eth.L1BlockRef
 	startCh     chan uint64
 	exitCh      chan struct{}
@@ -155,6 +158,7 @@ func newWorker(
 		dataReader:       dr,
 		prover:           prover,
 		chainHeadCh:      chainHeadCh,
+		headUpdateCh:     make(chan struct{}, 1),
 		shardTaskMap:     make(map[uint64]task),
 		exitCh:           make(chan struct{}),
 		startCh:          make(chan uint64, 1),
@@ -181,6 +185,27 @@ func newWorker(
 	go worker.newWorkLoop()
 	go worker.resultLoop()
 	return worker
+}
+
+func (w *worker) updateLatestL1Head(incoming uint64) {
+	for {
+		current := atomic.LoadUint64(&w.latestL1Head)
+		if incoming <= current {
+			w.lg.Info("L1 head is already updated", "current", current, "incoming", incoming)
+			return
+		}
+		if atomic.CompareAndSwapUint64(&w.latestL1Head, current, incoming) {
+			w.lg.Info("Latest L1 head updated", "current", current, "incoming", incoming)
+			select {
+			case w.headUpdateCh <- struct{}{}:
+				w.lg.Info("headUpdateCh notified", "current", current, "incoming", incoming)
+			default:
+				w.lg.Info("headUpdateCh notification skipped to avoid blocking", "current", current, "incoming", incoming)
+			}
+			return
+		}
+		w.lg.Info("Concurrent L1 head update detected, retrying", "current", current, "incoming", incoming)
+	}
 }
 
 func (w *worker) start() {
@@ -275,6 +300,7 @@ func (w *worker) newWorkLoop() {
 			w.shardTaskMap[shardIdx] = task
 
 		case block := <-w.chainHeadCh:
+			w.updateLatestL1Head(block.Number)
 			if !w.isRunning() {
 				break
 			}
@@ -410,6 +436,28 @@ func (w *worker) notifyResultLoop() {
 	}
 }
 
+// waitUntilBlockAdvanced waits until L1 head is strictly newer than the mined block.
+func (w *worker) waitUntilBlockAdvanced(mined uint64) bool {
+	loggedWaiting := false
+	for {
+		latest := atomic.LoadUint64(&w.latestL1Head)
+		if latest > mined {
+			w.lg.Info("L1 head advanced since mined block", "mined", mined, "latest", latest)
+			return true
+		}
+		if !loggedWaiting {
+			w.lg.Info("Hold on submitting mining result until L1 head advances", "mined", mined, "latest", latest)
+			loggedWaiting = true
+		}
+		select {
+		case <-w.headUpdateCh:
+			w.lg.Info("L1 head update received", "mined", mined, "latest", atomic.LoadUint64(&w.latestL1Head))
+		case <-w.exitCh:
+			return false
+		}
+	}
+}
+
 // resultLoop is a standalone goroutine to submit mining result to L1 contract.
 func (w *worker) resultLoop() {
 	defer w.wg.Done()
@@ -426,12 +474,9 @@ func (w *worker) resultLoop() {
 				continue
 			}
 			w.lg.Info("Mining result loop get result", "shard", result.startShardId, "block", result.blockNumber, "nonce", result.nonce)
-
-			// Mining result comes within the same block time window
-			if tillNextSlot := int64(result.timestamp) + int64(w.config.Slot) - time.Now().Unix(); tillNextSlot > 0 {
-				// Wait until next block comes to avoid empty blockhash on gas estimation
-				w.lg.Info("Hold on submitting mining result till block+1", "block", result.blockNumber, "secondsToWait", tillNextSlot)
-				time.Sleep(time.Duration(tillNextSlot) * time.Second)
+			// Wait until next block comes to avoid empty blockhash on gas estimation
+			if !w.waitUntilBlockAdvanced(result.blockNumber.Uint64()) {
+				return
 			}
 			txHash, err := w.l1API.SubmitMinedResult(
 				context.Background(),


### PR DESCRIPTION

### Issue
The `FailedToObtainBlockhash` issue was reproduced:
```
INFO [03-09|14:19:15.072] Calculated a valid hash                  shard=0 block=10,414,872 timestamp=1,773,062,352 randao=8651fa..436b57 nonce=170,011 hash0=d04672..40e44a hash1=000000..8ce8a8 sampleIdxs="[2285954122 5178046772]"
...
INFO [03-09|14:19:40.388] Mining result loop get result            shard=0 block=10,414,872 nonce=170,011
...
ERROR[03-09|14:19:40.399] Estimate gas failed                      error="execution reverted: ErrorData: 0x4882d76b: StorageContract_FailedToObtainBlockhash()"
```

### Cause

The chain head stayed as 10,414,872 for 3 slots during the block mined and tx estimated. The fix in https://github.com/ethstorage/es-node/pull/487 only waits for 1 slot at most.

We need the block number updates to avoid empty blockhash.

### Solution

This PR replaces slot-based waiting with a channel-based synchronization that ensures mining results are only submitted after the L1 head has advanced past the mined block. 

### Tests
Tests done in local devnet:

Waiting for L1 head to advance in the case of an empty slot:
```
INFO [03-11|11:59:26.576] Calculated a valid hash                  shard=37 block=10,424,641 timestamp=1,773,201,564 randao=3756ab..928ca0 nonce=541,929 hash0=ea0224..c03870 hash1=000001..326081 sampleIdxs="[1226864 1215777]"
...
INFO [03-11|11:59:40.490] Mining result loop get result            shard=37 block=10,424,641 nonce=541,929
INFO [03-11|11:59:40.490] L1 head not advanced since mined block, keep waiting mined=10,424,641 latest=10,424,641
INFO [03-11|11:59:40.490] Waiting for L1 head to advance           mined=10,424,641
INFO [03-11|11:59:49.055] headUpdateCh updated                     new=10,424,642
INFO [03-11|11:59:49.055] L1 head advanced since mined block       mined=10,424,641 latest=10,424,642
INFO [03-11|11:59:49.740] Composed calldata   ...                    
```

Normal case:
```
INFO [03-11|14:13:19.923] Calculated a valid hash                  shard=37 block=10,425,204 timestamp=1,773,209,592 randao=0d1b1f..4e2cb9 nonce=482,820 hash0=735e4e..03afb1 hash1=000001..b2a4e3 sampleIdxs="[1224625 1241249]"
...
INFO [03-11|14:13:36.915] Mining result loop get result            shard=37 block=10,425,204 nonce=482,820
INFO [03-11|14:13:36.915] L1 head advanced since mined block       mined=10,425,204 latest=10,425,205
INFO [03-11|14:13:38.683] Composed calldata                        ...
```