### PR TITLE
Estimate gas at pending block to fix `FailedToObtainBlockhash`

### DIFF
--- a/ethstorage/miner/l1_mining_api.go
+++ b/ethstorage/miner/l1_mining_api.go
@@ -161,16 +161,6 @@ func (m *l1MiningAPI) SubmitMinedResult(ctx context.Context, contract common.Add
 		return common.Hash{}, fmt.Errorf("failed to estimate gas: %v", errMessage)
 	}
 	m.lg.Info("Estimated gas done", "gas", estimatedGas)
-	// query current block number for debug
-	currentBlock, err := m.BlockNumber(ctx)
-	if err != nil {
-		m.lg.Warn("Failed to query current block number", "error", err)
-	} else {
-		m.lg.Info("Current block number", "blockNumber", currentBlock)
-	}
-	if currentBlock == rst.blockNumber.Uint64() {
-		m.lg.Warn("Current block number is the same as the mined block number, the tx might fail due to empty blockhash, consider to wait for next block", "blockNumber", currentBlock)
-	}
 
 	nonce, err := m.PendingNonceAt(ctx, cfg.SignerAddr)
 	if err != nil {

--- a/ethstorage/miner/l1_mining_api.go
+++ b/ethstorage/miner/l1_mining_api.go
@@ -147,20 +147,30 @@ func (m *l1MiningAPI) SubmitMinedResult(ctx context.Context, contract common.Add
 		return common.Hash{}, errDropped{reason: errMessage}
 	}
 
-	estimatedGas, err := m.EstimateGas(ctx, ethereum.CallMsg{
+	estimatedGas, err := m.EstimateGasAtBlock(ctx, ethereum.CallMsg{
 		From:      cfg.SignerAddr,
 		To:        &contract,
 		GasTipCap: tip,
 		GasFeeCap: gasFeeCap,
 		Value:     common.Big0,
 		Data:      calldata,
-	})
+	}, big.NewInt(rpc.PendingBlockNumber.Int64()))
 	if err != nil {
 		errMessage := parseErr(err)
 		m.lg.Error("Estimate gas failed", "error", errMessage)
 		return common.Hash{}, fmt.Errorf("failed to estimate gas: %v", errMessage)
 	}
 	m.lg.Info("Estimated gas done", "gas", estimatedGas)
+	// query current block number for debug
+	currentBlock, err := m.BlockNumber(ctx)
+	if err != nil {
+		m.lg.Warn("Failed to query current block number", "error", err)
+	} else {
+		m.lg.Info("Current block number", "blockNumber", currentBlock)
+	}
+	if currentBlock == rst.blockNumber.Uint64() {
+		m.lg.Warn("Current block number is the same as the mined block number, the tx might fail due to empty blockhash, consider to wait for next block", "blockNumber", currentBlock)
+	}
 
 	nonce, err := m.PendingNonceAt(ctx, cfg.SignerAddr)
 	if err != nil {

--- a/ethstorage/miner/worker.go
+++ b/ethstorage/miner/worker.go
@@ -426,13 +426,6 @@ func (w *worker) resultLoop() {
 				continue
 			}
 			w.lg.Info("Mining result loop get result", "shard", result.startShardId, "block", result.blockNumber, "nonce", result.nonce)
-
-			// Mining result comes within the same block time window
-			if tillNextSlot := int64(result.timestamp) + int64(w.config.Slot) - time.Now().Unix(); tillNextSlot > 0 {
-				// Wait until next block comes to avoid empty blockhash on gas estimation
-				w.lg.Info("Hold on submitting mining result till block+1", "block", result.blockNumber, "secondsToWait", tillNextSlot)
-				time.Sleep(time.Duration(tillNextSlot) * time.Second)
-			}
 			txHash, err := w.l1API.SubmitMinedResult(
 				context.Background(),
 				w.storageMgr.ContractAddress(),


### PR DESCRIPTION
This PR is another solution as an alternative to https://github.com/ethstorage/es-node/pull/506.

## Rationale

The EVM specification requires that `BLOCKHASH` can only access the most recent 256 generated blocks, i.e., `[block.number - 256, block.number - 1]`, excluding the current block itself.

`eth_estimateGas` executes in the context of the latest chain head block `N` [by default](https://github.com/ethereum/go-ethereum/blob/ab357151da881f0e7dffd30b639c9dcdcdd4cc10/internal/ethapi/api.go#L923), so `block.number = N`.
If `BLOCKHASH(N)` is called, since `N >= block.number`, it returns `0`.

When explicitly using the `pending` block tag, the execution context changes. In Geth, `block.number = N + 1`, i.e., the next block being constructed. Therefore, `BLOCKHASH(N)` becomes valid (since `N = block.number - 1`).

In real execution, the transaction is included in block `N + k` (where `k ≥ 1`), so `block.number = N + k`. In the common case where `k = 1`, this matches the `pending` context.

## Tests

Tests have been performed on the local testnet using extra temporary debug messages to confirm that the mining tx is completed successfully in the case of mining and estimation occurring in the same slot.