### PR TITLE
Fix invalid paramter in the Beacon query

### DIFF
--- a/ethstorage/eth/beacon_client.go
+++ b/ethstorage/eth/beacon_client.go
@@ -75,7 +75,6 @@ func (c *BeaconClient) DownloadBlobs(timestamp uint64, hashes []common.Hash) (ma
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf(">>>>>>>>>Querying beacon blobs with url %s\n", blobsUrl)
 	resp, err := http.Get(blobsUrl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query beacon blobs with url %s: %w", blobsUrl, err)

--- a/ethstorage/eth/beacon_client.go
+++ b/ethstorage/eth/beacon_client.go
@@ -75,6 +75,7 @@ func (c *BeaconClient) DownloadBlobs(timestamp uint64, hashes []common.Hash) (ma
 	if err != nil {
 		return nil, err
 	}
+	fmt.Printf(">>>>>>>>>Querying beacon blobs with url %s\n", blobsUrl)
 	resp, err := http.Get(blobsUrl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query beacon blobs with url %s: %w", blobsUrl, err)
@@ -121,7 +122,7 @@ func (c *BeaconClient) QueryUrlForV1BeaconBlobs(timestamp uint64, hashes []commo
 	}
 	q := url.Values{}
 	for _, h := range hashes {
-		q.Add("versioned_hash", h.Hex())
+		q.Add("versioned_hashes", h.Hex())
 	}
 	return blobsURL + "?" + q.Encode(), nil
 }


### PR DESCRIPTION
This PR fixes https://github.com/ethstorage/es-node/issues/508, which is caused by the wrong parameter `versioned_hash` used in the beacon query for blobs.

Tested with Lighthouse, Prysm, and Quicknode URLs, the blobs can be downloaded successfully with the specified versioned hash.

```
INFO [04-12|11:00:51.386] Don't find blob in the cache, will try to download directly blockNumber=10,641,248 start=10,641,248 end=10,641,276 toCache=true
>>>>>>>>>Querying beacon blobs with url http://65.108.236.27:5052/eth/v1/beacon/blobs/10019076?versioned_hashes=0x012be91960dc81750dfccc934b51999dadc1c222e6642ad3c58566a1c31524d0
INFO [04-12|11:00:55.343] Downloaded and encoded                   blockNumber=10,641,248 kvIdx=299
INFO [04-12|11:00:55.343] Set blockBlobs to cache                  block=10,641,248
```