### PR TITLE
refactor: modernize sync/atomic usage with typed atomic apis

### DIFF
--- a/ethstorage/miner/worker.go
+++ b/ethstorage/miner/worker.go
@@ -128,7 +128,7 @@ type worker struct {
 	miningStates     map[uint64]*MiningState
 	submissionStates map[uint64]*SubmissionState
 
-	running int32
+	running atomic.Int32
 	wg      sync.WaitGroup
 	lg      log.Logger
 }
@@ -185,16 +185,16 @@ func newWorker(
 
 func (w *worker) start() {
 	w.lg.Info("Worker is being started...")
-	atomic.StoreInt32(&w.running, 1)
+	w.running.Store(1)
 }
 
 func (w *worker) stop() {
 	w.lg.Warn("Worker is being stopped...")
-	atomic.StoreInt32(&w.running, 0)
+	w.running.Store(0)
 }
 
 func (w *worker) isRunning() bool {
-	return atomic.LoadInt32(&w.running) == 1
+	return w.running.Load() == 1
 }
 
 func (w *worker) close() {

--- a/ethstorage/pora/ethash/algorithm.go
+++ b/ethstorage/pora/ethash/algorithm.go
@@ -174,7 +174,7 @@ func generateCache(dest []uint32, epoch uint64, seed []byte) {
 	rows := int(size) / hashBytes
 
 	// Start a monitoring goroutine to report progress on low end devices
-	var progress uint32
+	var progress atomic.Uint32
 
 	done := make(chan struct{})
 	defer close(done)
@@ -185,7 +185,7 @@ func generateCache(dest []uint32, epoch uint64, seed []byte) {
 			case <-done:
 				return
 			case <-time.After(3 * time.Second):
-				lg.Info("Generating ethash verification cache", "percentage", atomic.LoadUint32(&progress)*100/uint32(rows)/(cacheRounds+1), "elapsed", common.PrettyDuration(time.Since(start)))
+				lg.Info("Generating ethash verification cache", "percentage", progress.Load()*100/uint32(rows)/(cacheRounds+1), "elapsed", common.PrettyDuration(time.Since(start)))
 			}
 		}
 	}()
@@ -196,7 +196,7 @@ func generateCache(dest []uint32, epoch uint64, seed []byte) {
 	keccak512(cache, seed)
 	for offset := uint64(hashBytes); offset < size; offset += hashBytes {
 		keccak512(cache[offset:], cache[offset-hashBytes:offset])
-		atomic.AddUint32(&progress, 1)
+		progress.Add(1)
 	}
 	// Use a low-round version of randmemohash
 	temp := make([]byte, hashBytes)
@@ -211,7 +211,7 @@ func generateCache(dest []uint32, epoch uint64, seed []byte) {
 			bitutil.XORBytes(temp, cache[srcOff:srcOff+hashBytes], cache[xorOff:xorOff+hashBytes])
 			keccak512(cache[dstOff:], temp)
 
-			atomic.AddUint32(&progress, 1)
+			progress.Add(1)
 		}
 	}
 	// Swap the byte order on big endian systems and return
@@ -310,7 +310,7 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 	var pend sync.WaitGroup
 	pend.Add(threads)
 
-	var progress uint64
+	var progress atomic.Uint64
 	for i := 0; i < threads; i++ {
 		go func(id int) {
 			defer pend.Done()
@@ -331,7 +331,7 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 				}
 				copy(dataset[index*hashBytes:], item)
 
-				if status := atomic.AddUint64(&progress, 1); status%percent == 0 {
+				if status := progress.Add(1); status%percent == 0 {
 					lg.Info("Generating DAG in progress", "percentage", (status*100)/(size/hashBytes), "elapsed", common.PrettyDuration(time.Since(start)))
 				}
 			}


### PR DESCRIPTION
Replace legacy sync/atomic function-based API (AddInt32, LoadInt32, etc.) 
with Go 1.19+ typed atomic types (atomic.Int32, atomic.Int64, etc.).

This change:
- Improves code readability by removing explicit address-of operators
- Enhances type safety at compile-time
- Provides better API ergonomics with method-based access
- Aligns with modern Go best practices (More info https://github.com/golang/go/issues/50860)
