### PR TITLE
Fix blob not found from disk occasionally

### DIFF
--- a/integration_tests/scripts/check_latest_blob.sh
+++ b/integration_tests/scripts/check_latest_blob.sh
@@ -36,7 +36,7 @@ echo "Failed to get latest block" >&2
 exit 1
 fi
 
-latest_dec=$((latest_dec - 64 - 32))  # adjust to finalized, and add some buffer (1 epoch) for blob downloading to disk
+latest_dec=$((latest_dec - 96 - 32))  # adjust to finalized, and add some buffer (1 epoch) for blob downloading to disk
 from_dec=$((latest_dec - lookback))
 from_hex="$(cast to-hex "$from_dec")"
 to_hex="$(cast to-hex "$latest_dec")"


### PR DESCRIPTION
**Issue to fix**

Check latest blob job in `Archive Service Healthcheck` workflow failed: 
```
Archive service blobs request failed (HTTP 500)
URL: https://archive.mainnet.ethstorage.io:9645/eth/v1/beacon/blobs/14196131?versioned_hashes=0x01d0cd1c559773411f53c07765405d280b69f325db9b62832bf23b64a8a605d6
Error: Process completed with exit code 
```

**Analysis**

According to the fact that a block gets finalized in [64 ~ 95 slots](https://notes.ethereum.org/@vbuterin/single_slot_finality), the adjustment of 64 slots from the latest block to the finalized one is not enough (even with a 32-slot buffer). 

To fix it, make it 96 on the safe side.

Tested in [this run](https://github.com/ethstorage/es-node/actions/runs/25038091839).
