### PR TITLE
Fix archive service check timeout: hardening the retry logic

### DIFF
--- a/.github/workflows/archive_service_healthcheck.yml
+++ b/.github/workflows/archive_service_healthcheck.yml
@@ -16,7 +16,7 @@ jobs:
     name: Check blob_sidecars API for critical blob
     if: ${{ github.repository == 'ethstorage/es-node' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     env:
       ARCHIVE_BLOB_SIDECARS_URL: https://archive.mainnet.ethstorage.io:9645/eth/v1/beacon/blob_sidecars/13164810?indices=3
       ARCHIVE_BLOB_HASH: "5475d05275aaae328b99a4f4058ac1e121eaa4e4d4d378d292d6130f32d6ede0"
@@ -43,10 +43,16 @@ jobs:
           : > "$resp_file"
 
           # Capture status code; use retries/timeouts to reduce flakiness.
+          # --retry / --retry-delay: retry on failure with backoff
+          # --retry-all-errors: retry on any error, not just transient ones
+          # --connect-timeout: time to wait for TCP connection / DNS
+          # --max-time: max total time per individual attempt
+          # --retry-max-time: cap on total time spent across all retries
           code="$(
             curl --silent --show-error --location \
-              --retry 3 --retry-delay 5 --retry-all-errors \
-              --connect-timeout 10 --max-time 30 \
+              --retry 10 --retry-delay 10 --retry-all-errors \
+              --connect-timeout 30 --max-time 120 \
+              --retry-max-time 600 \
               --output "$resp_file" --write-out '%{http_code}' \
               "$url" \
               || echo '000'


### PR DESCRIPTION
This PR tries to fix this workflow failure:

>curl: (28) Failed to connect to archive.mainnet.ethstorage.io port 9645 after 10002 ms: Timeout was reached
curl: (28) Failed to connect to archive.mainnet.ethstorage.io port 9645 after 10003 ms: Timeout was reached
curl: (28) Failed to connect to archive.mainnet.ethstorage.io port 9645 after 10002 ms: Timeout was reached
curl: (28) Failed to connect to archive.mainnet.ethstorage.io port 9645 after 10002 ms: Timeout was reached
HTTP status: 000000

Tested in this [run](https://github.com/ethstorage/es-node/actions/runs/27258066927)https://github.com/ethstorage/es-node/actions/runs/27258066927.