### PR TITLE
fix: enable Foundry .env file loading in contract deployment

### DIFF
--- a/.github/workflows/integration-test-l1.yml
+++ b/.github/workflows/integration-test-l1.yml
@@ -39,12 +39,15 @@ jobs:
           sleep 1536
 
       - name: Deploy Contracts
+        env:
+          FOUNDRY_ALLOW_PROJECT_ENV: "1"
         run: |
           cd ../storage-contracts-v1 
           git checkout main
           git pull
           npm install 
           git submodule init && git submodule update
+          export FOUNDRY_ALLOW_PROJECT_ENV=1
           ./script/deploy.sh 21 > deploy.log
           source $(ls -t deployments/EthStorageContractM2*.txt | head -n 1)
           export RPC_URL="http://127.0.0.1:32003"


### PR DESCRIPTION
## Description

Update the GitHub Actions workflow to enable Foundry to load environment variables from the `.env` configuration file in the `storage-contracts-v1` project directory during contract deployment.

## Reason for Change

The `storage-contracts-v1` repository contains a `.env` configuration file in its project directory that is used to configure Foundry's local environment variables. The latest `foundry-rs/foundry-toolchain@v1` has enhanced its security level and by default no longer loads environment variables from the project-level `.env` file.

By explicitly setting `FOUNDRY_ALLOW_PROJECT_ENV=1`, Foundry is allowed to correctly read the `.env` configuration file in the project directory.

## Changes

### .github/workflows/integration-test-l1.yml

Added `FOUNDRY_ALLOW_PROJECT_ENV=1` configuration in the "Deploy Contracts" step:

**GitHub Actions step-level environment variable:**
```yaml
- name: Deploy Contracts
  env:
    FOUNDRY_ALLOW_PROJECT_ENV: "1"
```

**Shell script export:**
```bash
export FOUNDRY_ALLOW_PROJECT_ENV=1
```

Both settings are required to ensure the environment variable is properly passed through different process layers.

## Test Reference

See workflow run: [Integration Test Run #32820620927](https://github.com/ethstorage/es-node/actions/runs/32820620927/job/97717723961)
