### PR TITLE
fix(init): reject negative shard indexes

### DIFF
--- a/cmd/es-node/main.go
+++ b/cmd/es-node/main.go
@@ -240,6 +240,11 @@ func EsNodeInit(ctx *cli.Context) error {
 	}
 	shardIndexes := ctx.Int64Slice(shardIndexFlagName)
 	lg.Info("Read flag", "name", shardIndexFlagName, "value", shardIndexes)
+	for _, shardIndex := range shardIndexes {
+		if shardIndex < 0 {
+			return fmt.Errorf("%s must be non-negative: %d", shardIndexFlagName, shardIndex)
+		}
+	}
 	shardLen := 0
 	if len(shardIndexes) == 0 {
 		shards := ctx.Int(shardLenFlagName)

--- a/cmd/es-node/main_test.go
+++ b/cmd/es-node/main_test.go
@@ -1,0 +1,40 @@
+// Copyright 2022-2023, EthStorage.
+// For license information, see https://github.com/ethstorage/es-node/blob/main/LICENSE
+
+package main
+
+import (
+	"testing"
+
+	"github.com/ethstorage/go-ethstorage/ethstorage/flags"
+	"github.com/urfave/cli"
+)
+
+func TestEsNodeInitRejectsNegativeShardIndex(t *testing.T) {
+	app := cli.NewApp()
+	app.Commands = []cli.Command{
+		{
+			Name: "init",
+			Flags: []cli.Flag{
+				cli.IntFlag{Name: encodingTypeFlagName},
+				cli.Int64SliceFlag{Name: shardIndexFlagName},
+				flags.DataDir,
+				flags.L1NodeAddr,
+				flags.StorageL1Contract,
+			},
+			Action: EsNodeInit,
+		},
+	}
+
+	err := app.Run([]string{
+		"es-node", "init",
+		"--encoding_type", "0",
+		"--shard_index=-1",
+		"--datadir", t.TempDir(),
+		"--l1.rpc", "invalid://rpc",
+		"--storage.l1contract", "0x0000000000000000000000000000000000000001",
+	})
+	if err == nil || err.Error() != "shard_index must be non-negative: -1" {
+		t.Fatalf("expected negative shard index error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- reject negative `--shard_index` values before connecting to L1
- add a CLI regression test for the invalid input

## Why

`--shard_index` is parsed as a signed 64-bit value, but initialization later converts each index to `uint64`. A value such as `-1` could therefore wrap to `18446744073709551615` instead of being rejected as invalid input. Validating immediately also avoids unnecessary RPC and configuration work.

The regression failed before the fix because initialization proceeded to the invalid RPC endpoint; after the fix it returns the exact non-negative validation error before any RPC work.

## Testing

- `go build -v ./cmd/...`
- `go test -v ./... -tags ci`
- `go vet -tags=ci ./...`
- `gofmt` and `git diff --check`